### PR TITLE
[TCL] Updated create_clock with VTR specific features

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -282,6 +282,11 @@ public:
         flushing_printf("Warning at line %d: %s\n", lineno_, msg.c_str());
     }
 
+    // Error message during parsing.
+    void log_error_msg(const std::string& msg) override {
+        flushing_fprintf(stderr, "%s", msg.c_str());
+    }
+
     bool error() { return error_; }
 
 private:

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <string>
 #include <unordered_map>
-#include <set>
 #include <vector>
 
 #include "sdc_timing_object.h"
@@ -302,6 +301,7 @@ class TimingObjectDatabase {
      */
     inline std::vector<std::string> get_clock_driver_objects() const {
         std::vector<std::string> all_clock_drivers;
+        all_clock_drivers.reserve(clock_driver_objects_.size());
         for (const ObjectId& object_id : clock_driver_objects_) {
             all_clock_drivers.push_back(object_id.to_string());
         }

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <string>
 #include <unordered_map>
+#include <set>
 #include <vector>
 
 #include "sdc_timing_object.h"
@@ -52,6 +53,8 @@ class TimingObjectDatabase {
     std::unordered_map<ObjectId, std::string> object_name;
     /// @brief A mapping between a port object and its direction.
     std::unordered_map<PortObjectId, PortDirection> port_direction_;
+    /// @brief A collection of all clock driver objects.
+    std::vector<ObjectId> clock_driver_objects_;
 
     /// @brief A collection of all cell objects.
     std::vector<CellObjectId> cell_objects;
@@ -102,16 +105,25 @@ class TimingObjectDatabase {
      *      The name of the port to create. This does not need to be unique.
      *  @param port_direction
      *      The direction of the port (i.e. input, output, or inout).
+     *  @param is_clock_driver
+     *      If this port is the driver of a clock in the netlist.
      *
      *  @return The ID of the created object.
      */
-    inline PortObjectId create_port_object(const std::string& port_name, PortDirection port_direction) {
+    inline PortObjectId create_port_object(const std::string& port_name,
+                                           PortDirection port_direction,
+                                           bool is_clock_driver) {
         assert(port_direction != PortDirection::UNKNOWN);
         PortObjectId port_object_id = PortObjectId("__vtr_obj_port_" + std::to_string(port_objects.size()));
         assert(object_name.count(port_object_id) == 0);
         object_name[port_object_id] = port_name;
         port_direction_[port_object_id] = port_direction;
         port_objects.push_back(port_object_id);
+
+        if (is_clock_driver) {
+            clock_driver_objects_.push_back(port_object_id);
+        }
+
         return port_object_id;
     }
 
@@ -120,14 +132,22 @@ class TimingObjectDatabase {
      *
      *  @param pin_name
      *      The name of the pin to create. This does not need to be unique.
+     *  @param is_clock_driver
+     *      If this port is the driver of a clock in the netlist.
      *
      *  @return The ID of the created object.
      */
-    inline PinObjectId create_pin_object(const std::string& pin_name) {
+    inline PinObjectId create_pin_object(const std::string& pin_name,
+                                         bool is_clock_driver) {
         PinObjectId pin_object_id = PinObjectId("__vtr_obj_pin_" + std::to_string(pin_objects.size()));
         assert(object_name.count(pin_object_id) == 0);
         object_name[pin_object_id] = pin_name;
         pin_objects.push_back(pin_object_id);
+
+        if (is_clock_driver) {
+            clock_driver_objects_.push_back(pin_object_id);
+        }
+
         return pin_object_id;
     }
 
@@ -272,6 +292,20 @@ class TimingObjectDatabase {
             all_pins.push_back(pin_id.to_string());
         }
         return all_pins;
+    }
+
+    /**
+     * @brief Get a list of the IDs of all clock driver objects.
+     *
+     * This returns a vector of strings to make it more convenient for the
+     * parser.
+     */
+    inline std::vector<std::string> get_clock_driver_objects() const {
+        std::vector<std::string> all_clock_drivers;
+        for (const ObjectId& object_id : clock_driver_objects_) {
+            all_clock_drivers.push_back(object_id.to_string());
+        }
+        return all_clock_drivers;
     }
 };
 

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -131,6 +131,9 @@ class Callback {
 
         virtual void parse_warning(const std::string& msg) = 0;
 
+        // Log error message in downstream tool.
+        virtual void log_error_msg(const std::string& msg) = 0;
+
     public:
         TimingObjectDatabase obj_database;
 };

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -305,6 +305,11 @@ std::vector<std::string> libsdcparse_all_cells_internal() {
     return sdcparse::g_callback->obj_database.get_cell_objects();
 }
 
+std::vector<std::string> libsdcparse_all_clock_drivers_internal() {
+    check_g_callback_defined();
+    return sdcparse::g_callback->obj_database.get_clock_driver_objects();
+}
+
 std::string libsdcparse_get_name_internal(const std::string& object_id) {
     check_g_callback_defined();
     return sdcparse::g_callback->obj_database.get_object_name(sdcparse::ObjectId(object_id));
@@ -322,17 +327,19 @@ std::string libsdcparse_get_object_type_internal(const std::string& object_id) {
 }
 
 std::string libsdcparse_create_port_internal(const std::string& port_name,
-                                              const std::string& port_dir_str) {
+                                             const std::string& port_dir_str,
+                                             bool is_clock_driver) {
     sdcparse::PortDirection port_dir = sdcparse::from_string_to_port_dir(port_dir_str);
     assert(port_dir != sdcparse::PortDirection::UNKNOWN);
 
     check_g_callback_defined();
-    return sdcparse::g_callback->obj_database.create_port_object(port_name, port_dir).to_string();
+    return sdcparse::g_callback->obj_database.create_port_object(port_name, port_dir, is_clock_driver).to_string();
 }
 
-std::string libsdcparse_create_pin_internal(const std::string& pin_name) {
+std::string libsdcparse_create_pin_internal(const std::string& pin_name,
+                                            bool is_clock_driver) {
     check_g_callback_defined();
-    return sdcparse::g_callback->obj_database.create_pin_object(pin_name).to_string();
+    return sdcparse::g_callback->obj_database.create_pin_object(pin_name, is_clock_driver).to_string();
 }
 
 std::string libsdcparse_create_cell_internal(const std::string& cell_name) {

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -109,6 +109,8 @@ std::vector<std::string> libsdcparse_all_pins_internal();
 
 std::vector<std::string> libsdcparse_all_cells_internal();
 
+std::vector<std::string> libsdcparse_all_clock_drivers_internal();
+
 std::string libsdcparse_get_name_internal(const std::string& object_id);
 
 bool libsdcparse_is_object_id_internal(const std::string& object_id);
@@ -116,9 +118,11 @@ bool libsdcparse_is_object_id_internal(const std::string& object_id);
 std::string libsdcparse_get_object_type_internal(const std::string& object_id);
 
 std::string libsdcparse_create_port_internal(const std::string& port_name,
-                                              const std::string& port_dir_str);
+                                             const std::string& port_dir_str,
+                                             bool is_clock_driver);
 
-std::string libsdcparse_create_pin_internal(const std::string& pin_name);
+std::string libsdcparse_create_pin_internal(const std::string& pin_name,
+                                            bool is_clock_driver);
 
 std::string libsdcparse_create_cell_internal(const std::string& cell_name);
 

--- a/src/tcl/tcl_interpreter.h
+++ b/src/tcl/tcl_interpreter.h
@@ -6,8 +6,6 @@
  * @brief   A TCL-interpreter object used to parse SDC files.
  */
 
-#include <cassert>
-#include <iostream>
 #include <tcl/tcl.h>
 #include <string>
 
@@ -129,9 +127,12 @@ class TclInterpreter {
      */
     void eval_file(const std::string& filename) {
         // Ensure that the class was initialized correctly.
-        assert(g_callback != nullptr);
         if (!init_success_) {
             g_callback->parse_error(0, "", "Failed to parse due to interpreter initialization error.");
+            return;
+        }
+        if (g_callback == nullptr) {
+            g_callback->parse_error(0, "", "Failed to parse due to callback not being registered.");
             return;
         }
 
@@ -188,15 +189,19 @@ class TclInterpreter {
      * the error came from.
      */
     void print_error_log_() {
-        std::cerr << "--- SDC TCL Parse Error ---" << std::endl;
+        g_callback->log_error_msg("--- SDC TCL Parse Error ---\n");
+        g_callback->log_error_msg("Message: ");
         const char* msg = Tcl_GetStringResult(interp);
-        std::cerr << "Message: " << msg << std::endl;
+        g_callback->log_error_msg(msg);
+        g_callback->log_error_msg("\n");
 
         const char* stack_trace = Tcl_GetVar(interp, "errorInfo", TCL_GLOBAL_ONLY);
         if (stack_trace) {
-            std::cerr << "Stack Trace:\n" << stack_trace << std::endl;
+            g_callback->log_error_msg("Stack Trace:\n");
+            g_callback->log_error_msg(stack_trace);
+            g_callback->log_error_msg("\n");
         }
-        std::cerr << "---------------------------" << std::endl;
+        g_callback->log_error_msg("---------------------------\n");
     }
 };
 

--- a/src/tcl/tcl_interpreter.h
+++ b/src/tcl/tcl_interpreter.h
@@ -6,6 +6,7 @@
  * @brief   A TCL-interpreter object used to parse SDC files.
  */
 
+#include <cassert>
 #include <tcl/tcl.h>
 #include <string>
 
@@ -127,12 +128,9 @@ class TclInterpreter {
      */
     void eval_file(const std::string& filename) {
         // Ensure that the class was initialized correctly.
+        assert(g_callback != nullptr && "Callback must be registered");
         if (!init_success_) {
             g_callback->parse_error(0, "", "Failed to parse due to interpreter initialization error.");
-            return;
-        }
-        if (g_callback == nullptr) {
-            g_callback->parse_error(0, "", "Failed to parse due to callback not being registered.");
             return;
         }
 

--- a/test/doc_examples/A.sdc
+++ b/test/doc_examples/A.sdc
@@ -1,10 +1,11 @@
 # RUN: %sdcparse-test %s 2>&1 | filecheck %s
 
 # CHECK: [[clk1_port_ptr:__vtr_obj_port_[0-9]+]]
-puts [libsdcparse_create_port "clk1" -direction INPUT]
+puts [libsdcparse_create_port "clk1" -direction INPUT -clock_driver]
+puts [libsdcparse_create_port "in1" -direction INPUT]
+puts [libsdcparse_create_port "in2" -direction INPUT]
+puts [libsdcparse_create_port "out1" -direction OUTPUT]
+puts [libsdcparse_create_port "out2" -direction OUTPUT]
 
-# TODO: This is not technically correct. To make this test better, we need to
-#       have IO ports and produce warnings that we are trying to treate a non-clock
-#       as a clock.
 # CHECK: create_clock -period {{0.0*}} -waveform {{{0.0*}} {{0.0*}}} {[[clk1_port_ptr]]}
 create_clock -period 0 *

--- a/test/old_tests/test5.sdc
+++ b/test/old_tests/test5.sdc
@@ -3,6 +3,8 @@
 # COM: TODO: Add the filecheck.
 
 # COM: TODO: We can make this more interesting.
+puts [libsdcparse_create_port "clk1" -direction INPUT -clock_driver]
+puts [libsdcparse_create_port "clk2" -direction INPUT -clock_driver]
 puts [libsdcparse_create_port "in1" -direction INPUT]
 puts [libsdcparse_create_port "in2" -direction INPUT]
 puts [libsdcparse_create_port "in3" -direction INPUT]


### PR DESCRIPTION
The create_clock command should be able to reference either ports or pins; however, VTR allows for a special scenario where the user wants to set the clock period of all clocks easily. To do this, VTR reserves the wildcard syntax for the create_clock target to mean that all clock drivers should be referenced.

Updated the parser to adhere to this.

Also fixed some logging issues on the VTR side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clock driver tracking for ports and pins via new command-line options.
  * Enabled wildcard support in clock creation commands to automatically apply to all clock drivers.

* **Bug Fixes**
  * Improved error message reporting through enhanced callback system.

* **Chores**
  * Removed unused dependencies from internal headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->