### PR TITLE
[SDC] Added support for nets

### DIFF
--- a/src/sdc_timing_object.h
+++ b/src/sdc_timing_object.h
@@ -19,6 +19,7 @@ enum class ObjectType {
     Clock,  ///< Clock type. This is created by commands such as create_clock.
     Port,   ///< Port type. This is a top-level pin.
     Pin,    ///< Pin type. This is a pin on a cell.
+    Net,    ///< Net type. This is a net connecting a set of ports/pins.
     Unknown ///< Unknown type. Should never see this.
 };
 
@@ -31,6 +32,7 @@ inline std::string to_string(ObjectType object_type) {
         case ObjectType::Clock: return "clock";
         case ObjectType::Port: return "port";
         case ObjectType::Pin: return "pin";
+        case ObjectType::Net: return "net";
         default: return "unknown";
     }
 }
@@ -103,6 +105,13 @@ struct PinObjectId final : ObjectId {
     using ObjectId::ObjectId;
 };
 
+/**
+ * @brief A strong identifier to a net object.
+ */
+struct NetObjectId final : ObjectId {
+    using ObjectId::ObjectId;
+};
+
 } // namespace sdcparse
 
 // The following are hash functions for the strong IDs above to allow them to
@@ -136,6 +145,12 @@ struct hash<sdcparse::PortObjectId> {
 template<>
 struct hash<sdcparse::PinObjectId> {
     std::size_t operator()(const sdcparse::PinObjectId& obj) const noexcept {
+        return std::hash<std::string>{}(obj.to_string());
+    }
+};
+template<>
+struct hash<sdcparse::NetObjectId> {
+    std::size_t operator()(const sdcparse::NetObjectId& obj) const noexcept {
         return std::hash<std::string>{}(obj.to_string());
     }
 };

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -63,6 +63,8 @@ class TimingObjectDatabase {
     std::vector<PortObjectId> port_objects;
     /// @brief A collection of all pin objects.
     std::vector<PinObjectId> pin_objects;
+    /// @brief A collection of all net objects.
+    std::vector<NetObjectId> net_objects;
 
   public:
     /**
@@ -151,6 +153,23 @@ class TimingObjectDatabase {
     }
 
     /**
+     * @brief Create a net object.
+     *
+     *  @param net_name
+     *      The name of the net to create. This does not need to be unique.
+     *
+     *  @return The ID of the created object.
+     */
+    inline NetObjectId create_net_object(const std::string& net_name) {
+        NetObjectId net_object_id = NetObjectId("__vtr_obj_net_" + std::to_string(net_objects.size()));
+        assert(object_name.count(net_object_id) == 0);
+        object_name[net_object_id] = net_name;
+        net_objects.push_back(net_object_id);
+
+        return net_object_id;
+    }
+
+    /**
      * @brief Check if the given string represents an object.
      *
      * Since we are using strings to identify objects, we need to prepend all
@@ -180,6 +199,8 @@ class TimingObjectDatabase {
             return ObjectType::Port;
         if (object_id.rfind("__vtr_obj_pin_", 0) == 0)
             return ObjectType::Pin;
+        if (object_id.rfind("__vtr_obj_net_", 0) == 0)
+            return ObjectType::Net;
 
         return ObjectType::Unknown;
     }
@@ -291,6 +312,21 @@ class TimingObjectDatabase {
             all_pins.push_back(pin_id.to_string());
         }
         return all_pins;
+    }
+
+    /**
+     * @brief Get a list of the IDs of all net objects.
+     *
+     * This returns a vector of strings to make it more convenient for the
+     * parser.
+     */
+    inline std::vector<std::string> get_net_objects() const {
+        std::vector<std::string> all_nets;
+        all_nets.reserve(net_objects.size());
+        for (const NetObjectId& net_id : net_objects) {
+            all_nets.push_back(net_id.to_string());
+        }
+        return all_nets;
     }
 
     /**

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -310,6 +310,11 @@ std::vector<std::string> libsdcparse_all_clock_drivers_internal() {
     return sdcparse::g_callback->obj_database.get_clock_driver_objects();
 }
 
+std::vector<std::string> libsdcparse_all_nets_internal() {
+    check_g_callback_defined();
+    return sdcparse::g_callback->obj_database.get_net_objects();
+}
+
 std::string libsdcparse_get_name_internal(const std::string& object_id) {
     check_g_callback_defined();
     return sdcparse::g_callback->obj_database.get_object_name(sdcparse::ObjectId(object_id));
@@ -345,6 +350,11 @@ std::string libsdcparse_create_pin_internal(const std::string& pin_name,
 std::string libsdcparse_create_cell_internal(const std::string& cell_name) {
     check_g_callback_defined();
     return sdcparse::g_callback->obj_database.create_cell_object(cell_name).to_string();
+}
+
+std::string libsdcparse_create_net_internal(const std::string& net_name) {
+    check_g_callback_defined();
+    return sdcparse::g_callback->obj_database.create_net_object(net_name).to_string();
 }
 
 void libsdcparse_raise_warning(const std::string& msg) {

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -111,6 +111,8 @@ std::vector<std::string> libsdcparse_all_cells_internal();
 
 std::vector<std::string> libsdcparse_all_clock_drivers_internal();
 
+std::vector<std::string> libsdcparse_all_nets_internal();
+
 std::string libsdcparse_get_name_internal(const std::string& object_id);
 
 bool libsdcparse_is_object_id_internal(const std::string& object_id);
@@ -125,4 +127,6 @@ std::string libsdcparse_create_pin_internal(const std::string& pin_name,
                                             bool is_clock_driver);
 
 std::string libsdcparse_create_cell_internal(const std::string& cell_name);
+
+std::string libsdcparse_create_net_internal(const std::string& net_name);
 

--- a/test/basic/create_clock.sdc
+++ b/test/basic/create_clock.sdc
@@ -12,6 +12,8 @@ puts [libsdcparse_create_port "clk4" -direction INPUT]
 puts [libsdcparse_create_port "clk5" -direction INPUT]
 # CHECK: [[clk6_port_ptr:__vtr_obj_port_[0-9]+]]
 puts [libsdcparse_create_port "clk6" -direction INPUT]
+# CHECK: [[clk7_net_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net "clk7_net"]
 
 # CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[clk1_port_ptr]]}
 create_clock -period 1.0 clk1
@@ -30,3 +32,9 @@ create_clock -period 5 -name Jeff
 
 # CHECK: create_clock -period {{3.0*}} -waveform {{{1.0*}} {{2.0*}}} {[[clk6_port_ptr]]}
 create_clock -period 3 -waveform {1 2} clk6
+
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[clk7_net_ptr]]}
+create_clock -period 1.0 clk7_net
+
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[clk7_net_ptr]]}
+create_clock -period 1.0 [get_nets clk7_net]

--- a/test/basic/get_nets.sdc
+++ b/test/basic/get_nets.sdc
@@ -1,0 +1,49 @@
+# RUN: %sdcparse-test %s &> %t
+# RUN: filecheck %s --input-file=%t
+
+# CHECK: [[net1_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net "net1"]
+# CHECK: [[net2_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net "net2"]
+# CHECK: [[net3_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net "net3"]
+
+# CHECK: [[net1_ptr]]
+puts [get_nets {net1}]
+
+# CHECK: [[net2_ptr]]
+puts [get_nets {net2}]
+
+# CHECK: [[net3_ptr]]
+puts [get_nets {net3}]
+
+# CHECK-DAG: [[net1_ptr]]
+# CHECK-DAG: [[net2_ptr]]
+# CHECK-DAG: [[net3_ptr]]
+# CHECK-NEXT: DONE
+puts [get_nets {net*}]
+puts "DONE"
+
+# CHECK-DAG: [[net1_ptr]]
+# CHECK-DAG: [[net2_ptr]]
+# CHECK-DAG: [[net3_ptr]]
+# CHECK-NEXT: DONE
+puts [get_nets -regexp {net.*}]
+puts "DONE"
+
+# CHECK: [[net1_ptr]]
+puts [get_nets -nocase {NET1}]
+
+# CHECK-DAG: [[net1_ptr]]
+# CHECK-DAG: [[net2_ptr]]
+# CHECK-DAG: [[net3_ptr]]
+# CHECK-NEXT: DONE
+puts [get_nets -regexp -nocase {NET.*}]
+puts "DONE"
+
+# CHECK-DAG: [[net1_ptr]]
+# CHECK-DAG: [[net2_ptr]]
+# CHECK-DAG: [[net3_ptr]]
+# CHECK-NEXT: DONE
+puts [get_nets *]
+puts "DONE"


### PR DESCRIPTION
Found that many tools allow for the create_clock command to target nets (as well as ports and pins). This is a convenience feature where this implicitly means that the clock targets the driver of the given net.

Added this to the parser to be used in VTR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for net objects as a new object type in the timing database.
  * Added get_nets command to retrieve and query net objects with wildcard and regular expression filtering options.
  * Added libsdcparse_create_net command to create and register new net objects.
  * Extended clock creation commands to accept nets as valid timing object targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->