### PR TITLE
[SDC] Fixed Parse Issues with Backslash

### DIFF
--- a/test/strong/backslash_match.sdc
+++ b/test/strong/backslash_match.sdc
@@ -1,0 +1,10 @@
+# RUN: %sdcparse-test %s 2>&1 | filecheck %s
+
+# CHECK: [[net1_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net {\u}]
+
+# CHECK: \u
+puts [get_name [get_nets *]]
+
+# CHECK: [[net1_ptr]]
+puts [get_nets {\\u}]

--- a/test/strong/benchmarks/mes_noc.sdc
+++ b/test/strong/benchmarks/mes_noc.sdc
@@ -1,0 +1,13 @@
+# RUN: %sdcparse-test %s 2>&1 | filecheck %s
+
+# CHECK: [[net1_ptr:__vtr_obj_net_[0-9]+]]
+puts [libsdcparse_create_net {pll_noc_type2:\using_pll:use_noc_pll_2|altpll:altpll_component|pll_noc_type2_altpll:auto_generated|wire_pll1_clk[0]}]
+
+# CHECK: pll_noc_type2:\using_pll:use_noc_pll_2|altpll:altpll_component|pll_noc_type2_altpll:auto_generated|wire_pll1_clk[0]
+puts [get_name [get_nets *]]
+
+# CHECK: [[net1_ptr]]
+puts [get_nets {pll_noc_type2:\\using_pll:use_noc_pll_2\|altpll:altpll_component\|pll_noc_type2_altpll:auto_generated\|wire_pll1_clk\[0\]}]
+
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[net1_ptr]]}
+create_clock -period 1.000 {pll_noc_type2:\\using_pll:use_noc_pll_2\|altpll:altpll_component\|pll_noc_type2_altpll:auto_generated\|wire_pll1_clk\[0\]}

--- a/test/strong/special_characters.sdc
+++ b/test/strong/special_characters.sdc
@@ -1,0 +1,65 @@
+# RUN: %sdcparse-test %s 2>&1 | filecheck %s
+
+# CHECK: [[LSB_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {Lsquare[bracket} -direction INPUT]
+# CHECK: [[RSB_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {Rsquare]bracket} -direction INPUT]
+# CHECK: [[SS_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {slash/symbol} -direction INPUT]
+# CHECK: [[PS_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {period.symbol} -direction INPUT]
+# CHECK: [[MM_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {money$money} -direction INPUT]
+
+# CHECK-DAG: Lsquare[bracket
+# CHECK-DAG: Rsquare]bracket
+# CHECK-DAG: slash/symbol
+# CHECK-DAG: period.symbol
+# CHECK-DAG: money$money
+foreach port [get_ports *] {
+    puts [get_name $port]
+}
+
+# CHECK: [[LSB_ptr]]
+puts [get_ports Lsquare\[bracket]
+# CHECK: [[RSB_ptr]]
+puts [get_ports Rsquare\]bracket]
+# CHECK: [[SS_ptr]]
+puts [get_ports slash/symbol]
+# CHECK: [[PS_ptr]]
+puts [get_ports period.symbol]
+# CHECK: [[MM_ptr]]
+puts [get_ports money\$money]
+
+# CHECK: [[LSB_ptr]]
+puts [get_ports {Lsquare[bracket}]
+# CHECK: [[RSB_ptr]]
+puts [get_ports {Rsquare]bracket}]
+# CHECK: [[SS_ptr]]
+puts [get_ports {slash/symbol}]
+# CHECK: [[PS_ptr]]
+puts [get_ports {period.symbol}]
+# CHECK: [[MM_ptr]]
+puts [get_ports {money$money}]
+
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[LSB_ptr]]}
+create_clock -period 1.0 Lsquare\[bracket
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[RSB_ptr]]}
+create_clock -period 1.0 Rsquare\]bracket
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[SS_ptr]]}
+create_clock -period 1.0 slash/symbol
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[PS_ptr]]}
+create_clock -period 1.0 period.symbol
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[MM_ptr]]}
+create_clock -period 1.0 money\$money
+
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[LSB_ptr]]}
+create_clock -period 1.0 {Lsquare\[bracket}
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[RSB_ptr]]}
+create_clock -period 1.0 {Rsquare\]bracket}
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[SS_ptr]]}
+create_clock -period 1.0 {slash/symbol}
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[PS_ptr]]}
+create_clock -period 1.0 {period.symbol}
+# CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[MM_ptr]]}
+create_clock -period 1.0 {money\$money}


### PR DESCRIPTION
While testing on the VTR side, found a special case where we were not handling backslashes correctly for pattern searching (specifically in the mes_noc benchmark). Fixed it on the parser side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved pattern matching consistency through restructured matching logic. Enhanced error messages to provide clearer feedback when operations do not find expected targets.

* **Tests**
  * Added tests validating special character handling and consistency of network definitions across operations.
  * Added tests validating complex network configurations, timing constraints, and attribute preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->