### PR TITLE
[SDC] Moved the query pattern matching into C++ to improve performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++14 ${WARN_FLAGS}") 
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=leak -fsanitize=undefined") 
     set(FLEX_BISON_WARN_SUPPRESS_FLAGS "-Wno-switch-default -Wno-unused-parameter -Wno-missing-declarations")
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
 #Flex and Bison are used to generate the parser

--- a/src/sdc_timing_object.h
+++ b/src/sdc_timing_object.h
@@ -37,6 +37,15 @@ inline std::string to_string(ObjectType object_type) {
     }
 }
 
+inline ObjectType object_type_from_string(const std::string& object_type_str) {
+    if (object_type_str == "cell") return ObjectType::Cell;
+    if (object_type_str == "clock") return ObjectType::Clock;
+    if (object_type_str == "port") return ObjectType::Port;
+    if (object_type_str == "pin") return ObjectType::Pin;
+    if (object_type_str == "net") return ObjectType::Net;
+    return ObjectType::Unknown;
+}
+
 /**
  * @brief A strong identifier to an object.
  *

--- a/src/sdc_timing_object.h
+++ b/src/sdc_timing_object.h
@@ -37,6 +37,9 @@ inline std::string to_string(ObjectType object_type) {
     }
 }
 
+/**
+ * @brief Converts the given string to an object type.
+ */
 inline ObjectType object_type_from_string(const std::string& object_type_str) {
     if (object_type_str == "cell") return ObjectType::Cell;
     if (object_type_str == "clock") return ObjectType::Clock;

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -37,15 +37,15 @@ static inline std::string glob_to_regex(const std::string& glob) {
 namespace sdcparse {
 
 std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::vector<std::string>& patterns,
-                                                                   bool nocase,
-                                                                   bool regexp,
+                                                                   bool is_case_insensitive,
+                                                                   bool is_regex,
                                                                    const std::vector<ObjectType>& object_types) {
 
     // Pre-process the patterns.
     std::vector<std::regex> regex_patterns;
     for (const std::string& raw_pattern : patterns) {
         std::string pattern;
-        if (regexp) {
+        if (is_regex) {
             pattern = raw_pattern;
         } else {
             // TODO: A hand-rolled glob pattern matcher would likely be substantially faster.
@@ -53,7 +53,7 @@ std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::ve
             pattern = glob_to_regex(raw_pattern);
         }
         try {
-            if (nocase) {
+            if (is_case_insensitive) {
                 regex_patterns.emplace_back(pattern, std::regex::icase|std::regex::optimize);
             } else {
                 regex_patterns.emplace_back(pattern, std::regex::optimize);

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -103,7 +103,7 @@ std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::ve
                 }
                 break;
             default:
-                assert(false);
+                throw std::runtime_error("LibSDCParse: unexpected object type in query.");
                 break;
         }
     }

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -4,6 +4,11 @@
 
 /**
  * @brief Helper function to convert a glob pattern into a regex pattern.
+ * 
+ * NOTE: This function currently does not support character classes, instead
+ *       it just escapes square brackets to support buses correctly.
+ * 
+ * TODO: Should support character classes without breaking buses.
  *
  *  @param glob The glob pattern to convert.
  *
@@ -43,12 +48,18 @@ std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::ve
         if (regexp) {
             pattern = raw_pattern;
         } else {
+            // TODO: A hand-rolled glob pattern matcher would likely be substantially faster.
+            //       Should investigate.
             pattern = glob_to_regex(raw_pattern);
         }
-        if (nocase) {
-            regex_patterns.push_back(std::regex(pattern, std::regex::icase|std::regex::optimize));
-        } else {
-            regex_patterns.push_back(std::regex(pattern, std::regex::optimize));
+        try {
+            if (nocase) {
+                regex_patterns.push_back(std::regex(pattern, std::regex::icase|std::regex::optimize));
+            } else {
+                regex_patterns.push_back(std::regex(pattern, std::regex::optimize));
+            }
+        } catch (const std::regex_error& e) {
+            throw std::runtime_error("LibSDCParse: invalid pattern '" + raw_pattern + "': " + e.what());
         }
     }
 

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -1,0 +1,101 @@
+#include "sdc_timing_object_database.h"
+
+/**
+ * @brief Helper function to convert a glob pattern into a regex pattern.
+ * 
+ *  @param glob The glob pattern to convert.
+ *
+ *  @return The equivalent regex pattern.
+ */
+static inline std::string glob_to_regex(const std::string& glob) {
+    std::string res = "^"; // Ensure we match the whole string
+    for (char c : glob) {
+        switch (c) {
+            case '*':  res += ".*";  break;
+            case '?':  res += ".";   break;
+            // Escape regex special characters
+            case '.': case '+': case '(': case ')': 
+            case '[': case ']': case '{': case '}':
+            case '^': case '$': case '|': case '\\':
+                res += '\\';
+                res += c;
+                break;
+            default:   res += c;     break;
+        }
+    }
+    res += "$"; // Ensure we match until the end
+    return res;
+}
+
+namespace sdcparse {
+
+std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::vector<std::string>& patterns,
+                                                                   bool nocase,
+                                                                   bool regexp,
+                                                                   const std::vector<ObjectType>& object_types) {
+
+    // Pre-process the patterns.
+    std::vector<std::regex> regex_patterns;
+    for (const std::string& raw_pattern : patterns) {
+        std::string pattern;
+        if (regexp) {
+            pattern = raw_pattern;
+        } else {
+            pattern = glob_to_regex(raw_pattern);
+        }
+        if (nocase) {
+            regex_patterns.push_back(std::regex(pattern, std::regex::icase|std::regex::optimize));
+        } else {
+            regex_patterns.push_back(std::regex(pattern, std::regex::optimize));
+        }
+    }
+
+    std::vector<std::string> matches;
+
+    // Lambda to check an object against all patterns
+    auto check_object = [&matches, &regex_patterns](const ObjectId& object_id, const std::string& object_name) {
+        for (const std::regex& pattern : regex_patterns) {
+            if (std::regex_match(object_name, pattern)) {
+                matches.push_back(object_id.to_string());
+                return; // Early exit once we find a match
+            }
+        }
+    };
+
+    for (ObjectType target_object_type : object_types) {
+        switch (target_object_type) {
+            case ObjectType::Cell:
+                for (const CellObjectId& cell_object_id : cell_objects) {
+                    check_object(cell_object_id, get_object_name(cell_object_id));
+                }
+                break;
+            case ObjectType::Clock:
+                for (const ClockObjectId& clock_object_id : clock_objects) {
+                    check_object(clock_object_id, get_object_name(clock_object_id));
+                }
+                break;
+            case ObjectType::Net:
+                for (const NetObjectId& net_object_id : net_objects) {
+                    check_object(net_object_id, get_object_name(net_object_id));
+                }
+                break;
+            case ObjectType::Port:
+                for (const PortObjectId& port_object_id : port_objects) {
+                    check_object(port_object_id, get_object_name(port_object_id));
+                }
+                break;
+            case ObjectType::Pin:
+                for (const PinObjectId& pin_object_id : pin_objects) {
+                    check_object(pin_object_id, get_object_name(pin_object_id));
+                }
+                break;
+            default:
+                assert(false);
+                break;
+        }
+    }
+
+    return matches;
+}
+
+} // namespace sdcparse

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -54,9 +54,9 @@ std::vector<std::string> TimingObjectDatabase::query_pattern_match(const std::ve
         }
         try {
             if (nocase) {
-                regex_patterns.push_back(std::regex(pattern, std::regex::icase|std::regex::optimize));
+                regex_patterns.emplace_back(pattern, std::regex::icase|std::regex::optimize);
             } else {
-                regex_patterns.push_back(std::regex(pattern, std::regex::optimize));
+                regex_patterns.emplace_back(pattern, std::regex::optimize);
             }
         } catch (const std::regex_error& e) {
             throw std::runtime_error("LibSDCParse: invalid pattern '" + raw_pattern + "': " + e.what());

--- a/src/sdc_timing_object_database.cpp
+++ b/src/sdc_timing_object_database.cpp
@@ -1,8 +1,10 @@
 #include "sdc_timing_object_database.h"
 
+#include <regex>
+
 /**
  * @brief Helper function to convert a glob pattern into a regex pattern.
- * 
+ *
  *  @param glob The glob pattern to convert.
  *
  *  @return The equivalent regex pattern.
@@ -14,7 +16,7 @@ static inline std::string glob_to_regex(const std::string& glob) {
             case '*':  res += ".*";  break;
             case '?':  res += ".";   break;
             // Escape regex special characters
-            case '.': case '+': case '(': case ')': 
+            case '.': case '+': case '(': case ')':
             case '[': case ']': case '{': case '}':
             case '^': case '$': case '|': case '\\':
                 res += '\\';

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -41,26 +41,6 @@ inline PortDirection from_string_to_port_dir(const std::string& port_type) {
     return PortDirection::UNKNOWN;
 }
 
-inline std::string glob_to_regex(const std::string& glob) {
-    std::string res = "^"; // Ensure we match the whole string
-    for (char c : glob) {
-        switch (c) {
-            case '*':  res += ".*";  break;
-            case '?':  res += ".";   break;
-            // Escape regex special characters
-            case '.': case '+': case '(': case ')': 
-            case '[': case ']': case '{': case '}':
-            case '^': case '$': case '|': case '\\':
-                res += '\\';
-                res += c;
-                break;
-            default:   res += c;     break;
-        }
-    }
-    res += "$"; // Ensure we match until the end
-    return res;
-}
-
 /**
  * @brief Database of the timing objects in the netlist.
  *
@@ -366,74 +346,20 @@ class TimingObjectDatabase {
         return all_clock_drivers;
     }
 
-    inline std::vector<std::string> query_pattern_match(const std::vector<std::string>& patterns,
-                                                        bool nocase,
-                                                        bool regexp,
-                                                        const std::vector<ObjectType>& object_types) {
-
-        // Pre-process the patterns.
-        std::vector<std::regex> regex_patterns;
-        for (const std::string& raw_pattern : patterns) {
-            std::string pattern;
-            if (regexp) {
-                pattern = raw_pattern;
-            } else {
-                pattern = glob_to_regex(raw_pattern);
-            }
-            if (nocase) {
-                regex_patterns.push_back(std::regex(pattern, std::regex::icase|std::regex::optimize));
-            } else {
-                regex_patterns.push_back(std::regex(pattern, std::regex::optimize));
-            }
-        }
-
-        std::vector<std::string> matches;
-
-        // Lambda to check an object against all patterns
-        auto check_object = [&matches, &regex_patterns](const ObjectId& object_id, const std::string& object_name) {
-            for (const std::regex& pattern : regex_patterns) {
-                if (std::regex_match(object_name, pattern)) {
-                    matches.push_back(object_id.to_string());
-                    return; // Early exit once we find a match
-                }
-            }
-        };
-
-        for (ObjectType target_object_type : object_types) {
-            switch (target_object_type) {
-                case ObjectType::Cell:
-                    for (const CellObjectId& cell_object_id : cell_objects) {
-                        check_object(cell_object_id, get_object_name(cell_object_id));
-                    }
-                    break;
-                case ObjectType::Clock:
-                    for (const ClockObjectId& clock_object_id : clock_objects) {
-                        check_object(clock_object_id, get_object_name(clock_object_id));
-                    }
-                    break;
-                case ObjectType::Net:
-                    for (const NetObjectId& net_object_id : net_objects) {
-                        check_object(net_object_id, get_object_name(net_object_id));
-                    }
-                    break;
-                case ObjectType::Port:
-                    for (const PortObjectId& port_object_id : port_objects) {
-                        check_object(port_object_id, get_object_name(port_object_id));
-                    }
-                    break;
-                case ObjectType::Pin:
-                    for (const PinObjectId& pin_object_id : pin_objects) {
-                        check_object(pin_object_id, get_object_name(pin_object_id));
-                    }
-                    break;
-                default:
-                    assert(false);
-                    break;
-            }
-        }
-
-        return matches;
-    }
+    /**
+     * @brief Query the object database for objects of the given types with
+     *        names matching the given patterns.
+     * 
+     *  @param patterns     A list of patterns to search for.
+     *  @param regexp       Set to true to use a regex pattern matcher, false to use a glob pattern matcher.
+     *  @param object_types The types of objects to match for.
+     * 
+     *  @return A list of object IDs that match the query.
+     */
+    std::vector<std::string> query_pattern_match(const std::vector<std::string>& patterns,
+                                                 bool nocase,
+                                                 bool regexp,
+                                                 const std::vector<ObjectType>& object_types);
 };
 
 } // namespace sdcparse

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -8,10 +8,8 @@
  */
 
 #include <cassert>
-#include <regex>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "sdc_timing_object.h"
@@ -349,11 +347,11 @@ class TimingObjectDatabase {
     /**
      * @brief Query the object database for objects of the given types with
      *        names matching the given patterns.
-     * 
+     *
      *  @param patterns     A list of patterns to search for.
      *  @param regexp       Set to true to use a regex pattern matcher, false to use a glob pattern matcher.
      *  @param object_types The types of objects to match for.
-     * 
+     *
      *  @return A list of object IDs that match the query.
      */
     std::vector<std::string> query_pattern_match(const std::vector<std::string>& patterns,

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -348,16 +348,16 @@ class TimingObjectDatabase {
      * @brief Query the object database for objects of the given types with
      *        names matching the given patterns.
      *
-     *  @param patterns     A list of patterns to search for.
-     *  @param nocase       If true, performs case-insensitive matching.
-     *  @param regexp       Set to true to use a regex pattern matcher, false to use a glob pattern matcher.
-     *  @param object_types The types of objects to match for.
+     *  @param patterns             A list of patterns to search for.
+     *  @param is_case_insensitive  If true, performs case-insensitive matching.
+     *  @param is_regex             Set to true to use a regex pattern matcher, false to use a glob pattern matcher.
+     *  @param object_types         The types of objects to match for.
      *
      *  @return A list of object IDs that match the query.
      */
     std::vector<std::string> query_pattern_match(const std::vector<std::string>& patterns,
-                                                 bool nocase,
-                                                 bool regexp,
+                                                 bool is_case_insensitive,
+                                                 bool is_regex,
                                                  const std::vector<ObjectType>& object_types);
 };
 

--- a/src/sdc_timing_object_database.h
+++ b/src/sdc_timing_object_database.h
@@ -349,6 +349,7 @@ class TimingObjectDatabase {
      *        names matching the given patterns.
      *
      *  @param patterns     A list of patterns to search for.
+     *  @param nocase       If true, performs case-insensitive matching.
      *  @param regexp       Set to true to use a regex pattern matcher, false to use a glob pattern matcher.
      *  @param object_types The types of objects to match for.
      *

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "sdc_timing_object.h"
 #include "sdcparse.hpp"
 #include "sdc_commands.h"
 #include "tcl_interpreter.h"
@@ -329,6 +330,24 @@ std::string libsdcparse_get_object_type_internal(const std::string& object_id) {
     check_g_callback_defined();
     sdcparse::ObjectType object_type = sdcparse::g_callback->obj_database.get_object_type(object_id);
     return sdcparse::to_string(object_type);
+}
+
+std::vector<std::string> libsdcparse_query_pattern_match_internal(const std::vector<std::string>& patterns,
+                                                                  bool nocase,
+                                                                  bool regexp,
+                                                                  const std::vector<std::string>& object_types) {
+    check_g_callback_defined();
+
+    std::vector<sdcparse::ObjectType> target_object_types;
+    for (const std::string& object_string : object_types) {
+        sdcparse::ObjectType object_type = sdcparse::object_type_from_string(object_string);
+        if (object_type == sdcparse::ObjectType::Unknown) {
+            throw std::runtime_error("LibSDCParse: trying to query an invalid type.");
+        }
+        target_object_types.push_back(object_type);
+    }
+
+    return sdcparse::g_callback->obj_database.query_pattern_match(patterns, nocase, regexp, target_object_types);
 }
 
 std::string libsdcparse_create_port_internal(const std::string& port_name,

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -338,6 +338,7 @@ std::vector<std::string> libsdcparse_query_pattern_match_internal(const std::vec
                                                                   const std::vector<std::string>& object_types) {
     check_g_callback_defined();
 
+    // Collect a list of object types to parse.
     std::vector<sdcparse::ObjectType> target_object_types;
     for (const std::string& object_string : object_types) {
         sdcparse::ObjectType object_type = sdcparse::object_type_from_string(object_string);

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 #include "sdc_timing_object.h"
 #include "sdcparse.hpp"
@@ -339,13 +340,19 @@ std::vector<std::string> libsdcparse_query_pattern_match_internal(const std::vec
     check_g_callback_defined();
 
     // Collect a list of object types to parse.
+    std::unordered_set<sdcparse::ObjectType> seen_types;
     std::vector<sdcparse::ObjectType> target_object_types;
     for (const std::string& object_string : object_types) {
         sdcparse::ObjectType object_type = sdcparse::object_type_from_string(object_string);
         if (object_type == sdcparse::ObjectType::Unknown) {
             throw std::runtime_error("LibSDCParse: trying to query an invalid type.");
         }
+        if (seen_types.count(object_type) > 0) {
+            continue;
+        }
+
         target_object_types.push_back(object_type);
+        seen_types.insert(object_type);
     }
 
     return sdcparse::g_callback->obj_database.query_pattern_match(patterns, nocase, regexp, target_object_types);

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -119,6 +119,11 @@ bool libsdcparse_is_object_id_internal(const std::string& object_id);
 
 std::string libsdcparse_get_object_type_internal(const std::string& object_id);
 
+std::vector<std::string> libsdcparse_query_pattern_match_internal(const std::vector<std::string>& patterns,
+                                                                  bool nocase,
+                                                                  bool regexp,
+                                                                  const std::vector<std::string>& object_types);
+
 std::string libsdcparse_create_port_internal(const std::string& port_name,
                                              const std::string& port_dir_str,
                                              bool is_clock_driver);

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -194,30 +194,6 @@ proc libsdcparse_convert_to_objects {cmd_name targets object_type_list} {
             dict set params patterns [list $item]
             set matches [libsdcparse_query_get_impl $cmd_name $params $object_type_list]
             lappend id_targets {*}$matches
-            # foreach object_type $object_type_list {
-            #     switch -- $object_type {
-            #         "port" {
-            #             set matches [libsdcparse_query_get_impl $cmd_name libsdcparse_all_ports_internal $params]
-            #             lappend id_targets {*}$matches
-            #         }
-            #         "clock" {
-            #             set matches [libsdcparse_query_get_impl $cmd_name libsdcparse_all_clocks_internal $params]
-            #             lappend id_targets {*}$matches
-            #         }
-            #         "pin" {
-            #             set matches [libsdcparse_query_get_impl $cmd_name libsdcparse_all_pins_internal $params]
-            #             lappend id_targets {*}$matches
-            #         }
-            #         "cell" {
-            #             set matches [libsdcparse_query_get_impl $cmd_name libsdcparse_all_cells_internal $params]
-            #             lappend id_targets {*}$matches
-            #         }
-            #         "net" {
-            #             set matches [libsdcparse_query_get_impl $cmd_name libsdcparse_all_nets_internal $params]
-            #             lappend id_targets {*}$matches
-            #         }
-            #     }
-            # }
         }
     }
 
@@ -653,16 +629,15 @@ proc get_property {args} {
 # =====================================================================
 # Query "get" Implementation
 # =====================================================================
-# FIXME: Update this comment.
 # This procedure performs the query necessary for the get commands
 # provided by SDC (such as get_ports, get_clocks, etc.).
 #
 # This performs the necessary searches for a compliant SDC interface.
 #
 # Parameters:
-#   cmd_name  - Name of the command (for error reporting)
-#   all_func  - A function that is used to get all IDs for the query type.
-#   params    - The params that are passed into the search.
+#   cmd_name            - Name of the command (for error reporting)
+#   params              - The params that are passed into the search.
+#   target_object_types - A list of object types to query.
 # =====================================================================
 proc libsdcparse_query_get_impl {cmd_name params target_object_types} {
     set nocase [dict get $params -nocase]

--- a/test/strong/square_bracket_match.sdc
+++ b/test/strong/square_bracket_match.sdc
@@ -67,7 +67,9 @@ puts [get_ports B[*]]
 puts DONE
 
 # CHECK: [[B10_ptr]]
+# CHECK-NEXT: DONE
 puts [get_ports B[10]]
+puts DONE
 
 # TODO: Should we handle more interesting cases like A[3:0]?
 #       This will return A[3], A[2], A[1], A[0].

--- a/test/strong/square_bracket_match.sdc
+++ b/test/strong/square_bracket_match.sdc
@@ -61,6 +61,7 @@ puts DONE
 # CHECK-DAG: [[B1_ptr]]
 # CHECK-DAG: [[B2_ptr]]
 # CHECK-DAG: [[B3_ptr]]
+# CHECK-DAG: [[B10_ptr]]
 # CHECK-NEXT: DONE
 puts "get_ports B\[*\]:"
 puts [get_ports B[*]]

--- a/test/strong/square_bracket_match.sdc
+++ b/test/strong/square_bracket_match.sdc
@@ -16,6 +16,8 @@ puts [libsdcparse_create_port "B\[1\]" -direction INPUT]
 puts [libsdcparse_create_port "B\[2\]" -direction INPUT]
 # CHECK: [[B3_ptr:__vtr_obj_port_[0-9]+]]
 puts [libsdcparse_create_port "B\[3\]" -direction INPUT]
+# CHECK: [[B10_ptr:__vtr_obj_port_[0-9]+]]
+puts [libsdcparse_create_port {B[10]} -direction INPUT]
 
 # CHECK-DAG: [[A0_ptr]]
 # CHECK-DAG: [[A1_ptr]]
@@ -63,6 +65,9 @@ puts DONE
 puts "get_ports B\[*\]:"
 puts [get_ports B[*]]
 puts DONE
+
+# CHECK: [[B10_ptr]]
+puts [get_ports B[10]]
 
 # TODO: Should we handle more interesting cases like A[3:0]?
 #       This will return A[3], A[2], A[1], A[0].


### PR DESCRIPTION
In VPR, we found that for very large netlists the parser was running very slowly. To improve performance I moved the query functions into C++ which saves on moving the data into and out of the TCL interpreter.

On some of the largest circuits in VPR, I found that this improved SDC parse time by around 2.5x.

This also cleans up the query code to make it a bit more standard since we do not need to mess with the interpreter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pattern-matching queries with glob and regex support plus optional case-insensitive matching.
  * Queries can target multiple object types in a single call.

* **Improvements**
  * Consolidated query handling in the CLI/Tcl layer and improved error reporting when targets yield no matches.
  * Added string-to-object-type mapping for user-facing type names.

* **Chores**
  * Enabled export of compile_commands.json for build tooling.

* **Tests**
  * Added test covering bracketed port notation (B[10]).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->