### PR TITLE
Fix tcl include directory

### DIFF
--- a/src/tcl/tcl_interpreter.h
+++ b/src/tcl/tcl_interpreter.h
@@ -7,7 +7,7 @@
  */
 
 #include <cassert>
-#include <tcl/tcl.h>
+#include <tcl.h>
 #include <string>
 
 #include "sdc_wrapper.h"


### PR DESCRIPTION
Fedora (and I assume RHEL) installs tcl differently than Ubuntu and including tcl with <tcl/tcl.h> errors out there. This PR changes the include to have it work with both distributions.