### PR TITLE
[SDCParse] Removed String Groups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,8 @@
 
 using namespace sdcparse;
 
-void print_string_group(const StringGroup& group);
-void print_from_to_group(const StringGroup& from, const StringGroup& to);
+void print_object_id_vec(const std::vector<ObjectId>& group);
+void print_from_to_object_id_vec(const std::vector<ObjectId>& from, const std::vector<ObjectId>& to);
 
 class PrintCallback : public Callback {
 public:
@@ -51,9 +51,9 @@ public:
             flushing_printf(" -name %s",
                    cmd.name.c_str());
         }
-        if (!cmd.targets.strings.empty()) {
+        if (!cmd.targets.empty()) {
             flushing_printf(" ");
-            print_string_group(cmd.targets);
+            print_object_id_vec(cmd.targets);
         }
         if (cmd.add) {
             flushing_printf(" -add");
@@ -63,20 +63,15 @@ public:
         std::string clock_name = "";
         if (!cmd.name.empty()) {
             clock_name = cmd.name;
-            obj_database.create_clock_object(clock_name);
         } else {
-            if (cmd.targets.strings.empty()) {
+            if (cmd.targets.empty()) {
                 throw std::runtime_error("create_clock: clock name or target required");
             }
             // If no name is given, use the first target for the name. This
             // matches the behaviour of other tools.
-            if (cmd.targets.type == StringGroupType::OBJECT) {
-                clock_name = obj_database.get_object_name(ObjectId(cmd.targets.strings[0]));
-            } else {
-                clock_name = cmd.targets.strings[0];
-            }
-            obj_database.create_clock_object(clock_name);
+            clock_name = obj_database.get_object_name(ObjectId(cmd.targets[0]));
         }
+        obj_database.create_clock_object(clock_name);
     }
 
     void create_generated_clock(const CreateGeneratedClock& cmd) override {
@@ -86,14 +81,7 @@ public:
             flushing_printf(" -name %s",
                    cmd.name.c_str());
         }
-        std::string source_name;
-        if (cmd.source_string_type == StringGroupType::OBJECT) {
-            source_name = obj_database.get_object_name(ObjectId(cmd.source));
-        } else if (cmd.source_string_type == StringGroupType::STRING) {
-            source_name = cmd.source;
-        } else {
-            throw std::runtime_error("Unsupported string type group");
-        }
+        std::string source_name = obj_database.get_object_name(ObjectId(cmd.source));
         flushing_printf(" -source %s", source_name.c_str());
         if (cmd.divide_by != sdcparse::UNINITIALIZED_INT)
             flushing_printf(" -divide_by %d", cmd.divide_by);
@@ -102,29 +90,24 @@ public:
         if (cmd.add) {
             flushing_printf(" -add");
         }
-        if (!cmd.targets.strings.empty()) {
+        if (!cmd.targets.empty()) {
             flushing_printf(" ");
-            print_string_group(cmd.targets);
+            print_object_id_vec(cmd.targets);
         }
         flushing_printf("\n");
 
         std::string clock_name = "";
         if (!cmd.name.empty()) {
             clock_name = cmd.name;
-            obj_database.create_clock_object(clock_name);
         } else {
-            if (cmd.targets.strings.empty()) {
+            if (cmd.targets.empty()) {
                 throw std::runtime_error("create_generated_clock: clock name or target required");
             }
             // If no name is given, use the first target for the name. This
             // matches the behaviour of other tools.
-            if (cmd.targets.type == StringGroupType::OBJECT) {
-                clock_name = obj_database.get_object_name(ObjectId(cmd.targets.strings[0]));
-            } else {
-                clock_name = cmd.targets.strings[0];
-            }
-            obj_database.create_clock_object(clock_name);
+            clock_name = obj_database.get_object_name(ObjectId(cmd.targets[0]));
         }
+        obj_database.create_clock_object(clock_name);
     }
 
     void set_io_delay(const SetIoDelay& cmd) override {
@@ -148,7 +131,7 @@ public:
             flushing_printf(" -min");
         }
         flushing_printf(" %f ", cmd.delay);
-        print_string_group(cmd.target_ports);
+        print_object_id_vec(cmd.target_ports);
         flushing_printf("\n");
     }
     void set_clock_groups(const SetClockGroups& cmd) override {
@@ -165,7 +148,7 @@ public:
             flushing_printf(" -exclusive");
         for(const auto& clk_grp : cmd.clock_groups) {
             flushing_printf(" -group ");
-            print_string_group(clk_grp);
+            print_object_id_vec(clk_grp);
         }
         flushing_printf("\n");
     }
@@ -173,7 +156,7 @@ public:
     void set_false_path(const SetFalsePath& cmd) override {
         flushing_printf("#%s:%d\n", filename_.c_str(), lineno_);
         flushing_printf("set_false_path ");
-        print_from_to_group(cmd.from, cmd.to);
+        print_from_to_object_id_vec(cmd.from, cmd.to);
         flushing_printf("\n");
     }
     void set_min_max_delay(const SetMinMaxDelay& cmd) override {
@@ -184,7 +167,7 @@ public:
             flushing_printf("set_min_delay");
         }
         flushing_printf(" %f ", cmd.value);
-        print_from_to_group(cmd.from, cmd.to);
+        print_from_to_object_id_vec(cmd.from, cmd.to);
         flushing_printf("\n");
     }
     void set_multicycle_path(const SetMulticyclePath& cmd) override {
@@ -196,7 +179,7 @@ public:
         if(cmd.is_hold) {
             flushing_printf("-hold ");
         }
-        print_from_to_group(cmd.from, cmd.to);
+        print_from_to_object_id_vec(cmd.from, cmd.to);
         flushing_printf("\n");
     }
     void set_clock_uncertainty(const SetClockUncertainty& cmd) override {
@@ -208,7 +191,7 @@ public:
         if(cmd.is_hold) {
             flushing_printf("-hold ");
         }
-        print_from_to_group(cmd.from, cmd.to);
+        print_from_to_object_id_vec(cmd.from, cmd.to);
         flushing_printf(" %f ", cmd.value);
         flushing_printf("\n");
     }
@@ -225,13 +208,13 @@ public:
             flushing_printf("-late ");
         }
         flushing_printf("%f ", cmd.value);
-        print_string_group(cmd.target_clocks);
+        print_object_id_vec(cmd.target_clocks);
         flushing_printf("\n");
     }
     void set_disable_timing(const SetDisableTiming& cmd) override {
         flushing_printf("#%s:%d\n", filename_.c_str(), lineno_);
         flushing_printf("set_disable_timing ");
-        print_from_to_group(cmd.from, cmd.to);
+        print_from_to_object_id_vec(cmd.from, cmd.to);
         flushing_printf("\n");
     }
     void set_timing_derate(const SetTimingDerate& cmd) override {
@@ -251,7 +234,7 @@ public:
             flushing_printf("-cell_delay ");
         }
         flushing_printf("%f ", cmd.value);
-        print_string_group(cmd.cell_targets);
+        print_object_id_vec(cmd.cell_targets);
         flushing_printf("\n");
     }
 
@@ -314,56 +297,30 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void print_string_group(const StringGroup& group) {
-    const char *start_token, *end_token;
-    if(group.type == StringGroupType::STRING) {
-        start_token = "{";
-        end_token   = "}";
-    } else if (group.type == StringGroupType::OBJECT) {
-        start_token = "{";
-        end_token   = "}";
-    } else if (group.type == StringGroupType::CLOCK) {
-        start_token = "[get_clocks {";
-        end_token   = "}]";
+void print_object_id_vec(const std::vector<ObjectId>& object_ids) {
+    if (object_ids.empty())
+        return;
 
-    } else if (group.type == StringGroupType::PORT) {
-        start_token = "[get_ports {";
-        end_token   = "}]";
+    flushing_printf("{");
+    for (size_t i = 0; i < object_ids.size(); ++i) {
+        flushing_printf("%s", object_ids[i].to_string().c_str());
 
-    } else if (group.type == StringGroupType::CELL) {
-        start_token = "[get_cells {";
-        end_token   = "}]";
-    } else if (group.type == StringGroupType::PIN) {
-        start_token = "[get_pins {";
-        end_token   = "}]";
-
-    } else {
-        flushing_printf("Unsupported sdc string group type\n");
-        exit(1);
-    }
-
-    if(!group.strings.empty()) {
-        flushing_printf("%s", start_token);
-        for(size_t i = 0; i < group.strings.size(); ++i) {
-            flushing_printf("%s", group.strings[i].c_str());
-
-            if(i != group.strings.size() - 1) {
-                flushing_printf(" ");
-            }
+        if (i != object_ids.size() - 1) {
+            flushing_printf(" ");
         }
-        flushing_printf("%s", end_token);
     }
+    flushing_printf("}");
 }
 
-void print_from_to_group(const StringGroup& from, const StringGroup& to) {
-    if(!from.strings.empty()) {
+void print_from_to_object_id_vec(const std::vector<ObjectId>& from, const std::vector<ObjectId>& to) {
+    if(!from.empty()) {
         flushing_printf("-from ");
-        print_string_group(from);
+        print_object_id_vec(from);
     }
 
-    if(!to.strings.empty()) {
+    if(!to.empty()) {
         flushing_printf(" -to ");
-        print_string_group(to);
+        print_object_id_vec(to);
     }
 }
 

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -74,7 +74,6 @@ enum class IoDelayType;
 enum class ClockGroupsType;
 enum class FromToType;
 enum class McpType;
-enum class StringGroupType;
 
 struct CreateClock;
 struct CreateGeneratedClock;
@@ -87,8 +86,6 @@ struct SetClockUncertainty;
 struct SetClockLatency;
 struct SetDisableTiming;
 struct SetTimingDerate;
-
-struct StringGroup;
 
 class Callback {
 
@@ -181,31 +178,6 @@ enum class ClockLatencyType {
     NONE
 };
 
-enum class StringGroupType {
-    STRING, 
-    PORT, 
-    CLOCK,
-    CELL,
-    PIN,
-    OBJECT
-};
-
-/*
- * Common SDC data structures
- */
-
-struct StringGroup {
-    StringGroup() = default;
-    StringGroup(StringGroupType group_type)
-        : type(group_type) {}
-
-    StringGroupType type = StringGroupType::STRING;   //The type of the string group, default is STRING. 
-                                                            // Groups derived from 'calls' to [get_clocks {...}] 
-                                                            // and [get_ports {...}] will have types SDC_CLOCK 
-                                                            // and SDC_PORT respectively.
-    std::vector<std::string> strings;                       //The strings in the group
-};
-
 /*
  * Structures defining different SDC commands
  */
@@ -214,20 +186,18 @@ struct CreateClock {
     double period = UNINITIALIZED_FLOAT;        //Clock period
     double rise_edge = UNINITIALIZED_FLOAT;     //Rise time from waveform definition
     double fall_edge = UNINITIALIZED_FLOAT;     //Fall time from waveform definition
-    StringGroup targets;                        //The set of strings indicating clock sources.
-                                                // May be explicit strings or regexs.
+    std::vector<ObjectId> targets;              //The list of objects indicating clock sources.
     bool is_virtual = false;                    //Identifies this as a virtual (non-netlist) clock
     bool add = false;
 };
 
 struct CreateGeneratedClock {
     std::string name = "";
-    std::string source = "";
-    StringGroupType source_string_type = StringGroupType::STRING;
+    ObjectId source = ObjectId("");
     int divide_by = UNINITIALIZED_INT;
     int multiply_by = UNINITIALIZED_INT;
     bool add = false;
-    StringGroup targets;
+    std::vector<ObjectId> targets;
 };
 
 struct SetIoDelay {
@@ -246,17 +216,17 @@ struct SetIoDelay {
                                                     // implicitly specifying both)
     std::string clock_name = "";                    //Name of the clock this constraint is associated with
     double delay = UNINITIALIZED_FLOAT;             //The maximum input delay allowed on the target ports
-    StringGroup target_ports;                       //The target ports
+    std::vector<ObjectId> target_ports;             //The target ports
 };
 
 struct SetClockGroups {
     ClockGroupsType type = ClockGroupsType::NONE;   //The type of clock group relation being specified
-    std::vector<StringGroup> clock_groups;          //The groups of clocks
+    std::vector<std::vector<ObjectId>> clock_groups;//The groups of clocks
 };
 
 struct SetFalsePath {
-    StringGroup from;                           //The source list of startpoints or clocks
-    StringGroup to;                             //The target list of endpoints or clocks
+    std::vector<ObjectId> from;                     //The source list of startpoints or clocks
+    std::vector<ObjectId> to;                       //The target list of endpoints or clocks
 };
 
 struct SetMinMaxDelay {
@@ -266,8 +236,8 @@ struct SetMinMaxDelay {
     MinMaxType type = MinMaxType::NONE;         //Whether this is a min or max delay
     double value = UNINITIALIZED_FLOAT;         //The maximum/minimum allowed delay between the from
                                                 // and to clocks
-    StringGroup from;                           //The source list of startpoints or clocks
-    StringGroup to;                             //The target list of endpoints or clocks
+    std::vector<ObjectId> from;                 //The source list of startpoints or clocks
+    std::vector<ObjectId> to;                   //The target list of endpoints or clocks
 };
 
 struct SetMulticyclePath {
@@ -279,8 +249,8 @@ struct SetMulticyclePath {
                                                 // applying mcp_value for the setup mcp, and 0 for the hold 
                                                 // mcp)
     int mcp_value = UNINITIALIZED_INT;          //The number of cycles specifed
-    StringGroup from;                           //The source list of startpoints or clocks
-    StringGroup to;                             //The target list of endpoints or clocks
+    std::vector<ObjectId> from;                 //The source list of startpoints or clocks
+    std::vector<ObjectId> to;                   //The target list of endpoints or clocks
 };
 
 struct SetClockUncertainty {
@@ -292,8 +262,8 @@ struct SetClockUncertainty {
                                                 // implicitly specifying both)
     float value = UNINITIALIZED_FLOAT;          //The uncertainty value
 
-    StringGroup from;                           //Launch clock domain(s)
-    StringGroup to;                             //Capture clock domain(s)
+    std::vector<ObjectId> from;                 //Launch clock domain(s)
+    std::vector<ObjectId> to;                   //Capture clock domain(s)
 };
 
 struct SetClockLatency {
@@ -306,12 +276,12 @@ struct SetClockLatency {
                                                    // implicitly specifying both)
     float value = UNINITIALIZED_FLOAT;             //The latency value
 
-    StringGroup target_clocks;                     //The target clocks
+    std::vector<ObjectId> target_clocks;           //The target clocks
 };
 
 struct SetDisableTiming {
-    StringGroup from;                           //The source pins
-    StringGroup to;                             //The sink pins
+    std::vector<ObjectId> from;                    //The source pins
+    std::vector<ObjectId> to;                      //The sink pins
 };
 
 struct SetTimingDerate {
@@ -326,7 +296,7 @@ struct SetTimingDerate {
 
     float value = UNINITIALIZED_FLOAT;          //The derate value
 
-    StringGroup cell_targets;                   //The (possibly empty) set of target cells
+    std::vector<ObjectId> cell_targets;         //The (possibly empty) set of target cells
 };
 
 } //namespace

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -35,10 +35,10 @@ void libsdcparse_lineno_internal(int line_num) {
 }
 
 void libsdcparse_create_clock_internal(double period,
-                                        const std::string& name,
-                                        const std::vector<double>& waveform,
-                                        bool add,
-                                        const std::vector<std::string>& targets) {
+                                       const std::string& name,
+                                       const std::vector<double>& waveform,
+                                       bool add,
+                                       const std::vector<std::string>& targets) {
     sdcparse::CreateClock create_clock_cmd;
     create_clock_cmd.name = name;
     create_clock_cmd.period = period;
@@ -50,9 +50,9 @@ void libsdcparse_create_clock_internal(double period,
     else
         create_clock_cmd.is_virtual = false;
 
-    // TODO: Assert that all targets are IDs
-    create_clock_cmd.targets.strings = targets;
-    create_clock_cmd.targets.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& target : targets) {
+        create_clock_cmd.targets.push_back(sdcparse::ObjectId(target));
+    }
 
     create_clock_cmd.add = add;
 
@@ -61,37 +61,37 @@ void libsdcparse_create_clock_internal(double period,
 }
 
 void libsdcparse_create_generated_clock_internal(const std::string& name,
-                                                  const std::string& source,
-                                                  int divide_by,
-                                                  int multiply_by,
-                                                  bool add,
-                                                  const std::vector<std::string>& targets) {
+                                                 const std::string& source,
+                                                 int divide_by,
+                                                 int multiply_by,
+                                                 bool add,
+                                                 const std::vector<std::string>& targets) {
     sdcparse::CreateGeneratedClock create_gen_clock_cmd;
     create_gen_clock_cmd.name = name;
-    create_gen_clock_cmd.source = source;
-    create_gen_clock_cmd.source_string_type = sdcparse::StringGroupType::OBJECT;
+    create_gen_clock_cmd.source = sdcparse::ObjectId(source);
     create_gen_clock_cmd.divide_by = divide_by;
     create_gen_clock_cmd.multiply_by = multiply_by;
     create_gen_clock_cmd.add = add;
-    create_gen_clock_cmd.targets.strings = targets;
-    create_gen_clock_cmd.targets.type = sdcparse::StringGroupType::OBJECT;
+
+    for (const std::string& target : targets) {
+        create_gen_clock_cmd.targets.push_back(sdcparse::ObjectId(target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->create_generated_clock(create_gen_clock_cmd);
 }
 
 void libsdcparse_set_clock_groups_internal(const std::vector<std::string>& clock_list,
-                                            const std::vector<int>& clock_group_start_pos,
-                                            bool is_logically_exclusive,
-                                            bool is_physically_exclusive,
-                                            bool is_asynchronous) {
+                                           const std::vector<int>& clock_group_start_pos,
+                                           bool is_logically_exclusive,
+                                           bool is_physically_exclusive,
+                                           bool is_asynchronous) {
     sdcparse::SetClockGroups set_clock_groups_cmd;
     assert(clock_group_start_pos.size() > 1);
     for (size_t i = 0; i < clock_group_start_pos.size() - 1; i++) {
-        sdcparse::StringGroup new_group;
-        new_group.type = sdcparse::StringGroupType::OBJECT;
+        std::vector<sdcparse::ObjectId> new_group;
         for (size_t j = clock_group_start_pos[i]; j < (size_t)clock_group_start_pos[i + 1]; j++) {
-            new_group.strings.push_back(clock_list[j]);
+            new_group.push_back(sdcparse::ObjectId(clock_list[j]));
         }
         set_clock_groups_cmd.clock_groups.push_back(std::move(new_group));
     }
@@ -110,59 +110,67 @@ void libsdcparse_set_clock_groups_internal(const std::vector<std::string>& clock
 }
 
 void libsdcparse_set_false_path_internal(const std::vector<std::string>& from_list,
-                                          const std::vector<std::string>& to_list) {
+                                         const std::vector<std::string>& to_list) {
     sdcparse::SetFalsePath set_false_path_cmd;
-    set_false_path_cmd.from.strings = from_list;
-    set_false_path_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_false_path_cmd.to.strings = to_list;
-    set_false_path_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_false_path_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_false_path_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_false_path(set_false_path_cmd);
 }
 
 void libsdcparse_set_min_delay_internal(double delay,
-                                         const std::vector<std::string>& from_list,
-                                         const std::vector<std::string>& to_list) {
+                                        const std::vector<std::string>& from_list,
+                                        const std::vector<std::string>& to_list) {
     sdcparse::SetMinMaxDelay set_min_delay_cmd;
     set_min_delay_cmd.type = sdcparse::MinMaxType::MIN;
     set_min_delay_cmd.value = delay;
-    set_min_delay_cmd.from.strings = from_list;
-    set_min_delay_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_min_delay_cmd.to.strings = to_list;
-    set_min_delay_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_min_delay_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_min_delay_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_min_max_delay(set_min_delay_cmd);
 }
 
 void libsdcparse_set_max_delay_internal(double delay,
-                                         const std::vector<std::string>& from_list,
-                                         const std::vector<std::string>& to_list) {
+                                        const std::vector<std::string>& from_list,
+                                        const std::vector<std::string>& to_list) {
     sdcparse::SetMinMaxDelay set_max_delay_cmd;
     set_max_delay_cmd.type = sdcparse::MinMaxType::MAX;
     set_max_delay_cmd.value = delay;
-    set_max_delay_cmd.from.strings = from_list;
-    set_max_delay_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_max_delay_cmd.to.strings = to_list;
-    set_max_delay_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_max_delay_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_max_delay_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_min_max_delay(set_max_delay_cmd);
 }
 
 void libsdcparse_set_multicycle_path_internal(bool is_setup,
-                                               bool is_hold,
-                                               const std::vector<std::string>& from_list,
-                                               const std::vector<std::string>& to_list,
-                                               int path_multiplier) {
+                                              bool is_hold,
+                                              const std::vector<std::string>& from_list,
+                                              const std::vector<std::string>& to_list,
+                                              int path_multiplier) {
     sdcparse::SetMulticyclePath set_multicycle_path_cmd;
     set_multicycle_path_cmd.is_setup = is_setup;
     set_multicycle_path_cmd.is_hold = is_hold;
-    set_multicycle_path_cmd.from.strings = from_list;
-    set_multicycle_path_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_multicycle_path_cmd.to.strings = to_list;
-    set_multicycle_path_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_multicycle_path_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_multicycle_path_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
     set_multicycle_path_cmd.mcp_value = path_multiplier;
 
     check_g_callback_defined();
@@ -170,18 +178,19 @@ void libsdcparse_set_multicycle_path_internal(bool is_setup,
 }
 
 void libsdcparse_set_input_delay_internal(bool max_delay_flag,
-                                           bool min_delay_flag,
-                                           const std::string& clock_name,
-                                           double delay,
-                                           const std::vector<std::string>& targets) {
+                                          bool min_delay_flag,
+                                          const std::string& clock_name,
+                                          double delay,
+                                          const std::vector<std::string>& targets) {
 
     sdcparse::SetIoDelay set_input_delay_cmd;
     set_input_delay_cmd.is_max = max_delay_flag;
     set_input_delay_cmd.is_min = min_delay_flag;
     set_input_delay_cmd.clock_name = clock_name;
     set_input_delay_cmd.delay = delay;
-    set_input_delay_cmd.target_ports.strings = targets;
-    set_input_delay_cmd.target_ports.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& target_port : targets) {
+        set_input_delay_cmd.target_ports.push_back(sdcparse::ObjectId(target_port));
+    }
     set_input_delay_cmd.type = sdcparse::IoDelayType::INPUT;
 
     check_g_callback_defined();
@@ -189,18 +198,19 @@ void libsdcparse_set_input_delay_internal(bool max_delay_flag,
 }
 
 void libsdcparse_set_output_delay_internal(bool max_delay_flag,
-                                            bool min_delay_flag,
-                                            const std::string& clock_name,
-                                            double delay,
-                                            const std::vector<std::string>& targets) {
+                                           bool min_delay_flag,
+                                           const std::string& clock_name,
+                                           double delay,
+                                           const std::vector<std::string>& targets) {
 
     sdcparse::SetIoDelay set_output_delay_cmd;
     set_output_delay_cmd.is_max = max_delay_flag;
     set_output_delay_cmd.is_min = min_delay_flag;
     set_output_delay_cmd.clock_name = clock_name;
     set_output_delay_cmd.delay = delay;
-    set_output_delay_cmd.target_ports.strings = targets;
-    set_output_delay_cmd.target_ports.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& target_port : targets) {
+        set_output_delay_cmd.target_ports.push_back(sdcparse::ObjectId(target_port));
+    }
     set_output_delay_cmd.type = sdcparse::IoDelayType::OUTPUT;
 
     check_g_callback_defined();
@@ -208,17 +218,19 @@ void libsdcparse_set_output_delay_internal(bool max_delay_flag,
 }
 
 void libsdcparse_set_clock_uncertainty_internal(bool is_setup,
-                                                 bool is_hold,
-                                                 const std::vector<std::string>& from_list,
-                                                 const std::vector<std::string>& to_list,
-                                                 double uncertainty) {
+                                                bool is_hold,
+                                                const std::vector<std::string>& from_list,
+                                                const std::vector<std::string>& to_list,
+                                                double uncertainty) {
     sdcparse::SetClockUncertainty set_clock_uncertainty_cmd;
     set_clock_uncertainty_cmd.is_setup = is_setup;
     set_clock_uncertainty_cmd.is_hold = is_hold;
-    set_clock_uncertainty_cmd.from.strings = from_list;
-    set_clock_uncertainty_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_clock_uncertainty_cmd.to.strings = to_list;
-    set_clock_uncertainty_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_clock_uncertainty_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_clock_uncertainty_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
     set_clock_uncertainty_cmd.value = uncertainty;
 
     check_g_callback_defined();
@@ -226,10 +238,10 @@ void libsdcparse_set_clock_uncertainty_internal(bool is_setup,
 }
 
 void libsdcparse_set_clock_latency_internal(bool is_source,
-                                             bool is_early,
-                                             bool is_late,
-                                             double latency,
-                                             const std::vector<std::string>& targets) {
+                                            bool is_early,
+                                            bool is_late,
+                                            double latency,
+                                            const std::vector<std::string>& targets) {
     sdcparse::SetClockLatency set_clock_latency_cmd;
     if (is_source) {
         set_clock_latency_cmd.type = sdcparse::ClockLatencyType::SOURCE;
@@ -239,8 +251,9 @@ void libsdcparse_set_clock_latency_internal(bool is_source,
     set_clock_latency_cmd.is_early = is_early;
     set_clock_latency_cmd.is_late = is_late;
     set_clock_latency_cmd.value = latency;
-    set_clock_latency_cmd.target_clocks.strings = targets;
-    set_clock_latency_cmd.target_clocks.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& target : targets) {
+        set_clock_latency_cmd.target_clocks.push_back(sdcparse::ObjectId(target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_clock_latency(set_clock_latency_cmd);
@@ -249,29 +262,32 @@ void libsdcparse_set_clock_latency_internal(bool is_source,
 void libsdcparse_set_disable_timing_internal(const std::vector<std::string>& from_list,
                                               const std::vector<std::string>& to_list) {
     sdcparse::SetDisableTiming set_disable_timing_cmd;
-    set_disable_timing_cmd.from.strings = from_list;
-    set_disable_timing_cmd.from.type = sdcparse::StringGroupType::OBJECT;
-    set_disable_timing_cmd.to.strings = to_list;
-    set_disable_timing_cmd.to.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& from_target : from_list) {
+        set_disable_timing_cmd.from.push_back(sdcparse::ObjectId(from_target));
+    }
+    for (const std::string& to_target : to_list) {
+        set_disable_timing_cmd.to.push_back(sdcparse::ObjectId(to_target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_disable_timing(set_disable_timing_cmd);
 }
 
 void libsdcparse_set_timing_derate_internal(bool is_early,
-                                             bool is_late,
-                                             bool derate_nets,
-                                             bool derate_cells,
-                                             double derate,
-                                             const std::vector<std::string>& targets) {
+                                            bool is_late,
+                                            bool derate_nets,
+                                            bool derate_cells,
+                                            double derate,
+                                            const std::vector<std::string>& targets) {
     sdcparse::SetTimingDerate set_timing_derate_cmd;
     set_timing_derate_cmd.is_early = is_early;
     set_timing_derate_cmd.is_late = is_late;
     set_timing_derate_cmd.derate_nets = derate_nets;
     set_timing_derate_cmd.derate_cells = derate_cells;
     set_timing_derate_cmd.value = derate;
-    set_timing_derate_cmd.cell_targets.strings = targets;
-    set_timing_derate_cmd.cell_targets.type = sdcparse::StringGroupType::OBJECT;
+    for (const std::string& target : targets) {
+        set_timing_derate_cmd.cell_targets.push_back(sdcparse::ObjectId(target));
+    }
 
     check_g_callback_defined();
     sdcparse::g_callback->set_timing_derate(set_timing_derate_cmd);


### PR DESCRIPTION
String groups were used by the old parser to allow a vector of strings to represent different groups of objects (such as clocks, ports, etc.).

The ObjectIds provide a stronger interface which allows any object type to be identified by the IDs which can be stored in a list.

Now that the old parser has been removed, we can remove the String Groups in favor of vectors of IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined handling of timing constraint targets and clock specifications with unified object identification.
  * Consolidated printing formats for targets across delay, path, and clock operations.
  * Simplified internal target management and resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->