### PR TITLE
Add windows macos builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ set_target_properties(libsdcparse PROPERTIES PREFIX "") #Avoid extra 'lib' prefi
 
 target_link_libraries(libsdcparse
     PRIVATE
-    ${TCL_LIBRARY}
     sdc_commands
+    ${TCL_LIBRARY}
 )
 
 target_include_directories(libsdcparse
@@ -77,7 +77,15 @@ target_include_directories(libsdcparse
 
 #Create the test executable
 add_executable(sdcparse_test src/main.cpp)
-target_link_libraries(sdcparse_test libsdcparse)
+# note that we explicitly add sdc_commands to the dependencies below
+# so that we can ensure that TCL_LIBRARY is linked at the end, otherwise
+# CMake seems to add the sdc_commands implicit dependency after the TCL_LIBRARY
+# leading to linking errors on windows (mingw64-cmake)
+target_link_libraries(sdcparse_test
+    PRIVATE
+    libsdcparse
+    sdc_commands
+    ${TCL_LIBRARY})
 
 #Suppress IPO link warnings
 get_target_property(USES_IPO sdcparse_test INTERPROCEDURAL_OPTIMIZATION)

--- a/src/tcl/sdc_commands.i
+++ b/src/tcl/sdc_commands.i
@@ -92,9 +92,11 @@ extern int Sdc_commands_SafeInit(Tcl_Interp* interp);
 
 // Wrap all functions in a try-catch block to allow errors to be thrown from
 // within the interface functions.
+// $function is no longer recognized, and is replaced by $action
+// ref: https://swig.org/Release/CHANGES#:~:text=2025-06-09:%20olly%20The%20$function%20variable
 %exception {
     try {
-        $function;
+        $action;
     } catch (const std::out_of_range& oor) {
         SWIG_exception(SWIG_IndexError, oor.what());
     } catch (const std::exception& e) {


### PR DESCRIPTION
Changes:

- Ensure explicit correct linking order for `sdc_commands` library and `sdcparse_test` executable to fix issues on windows
- replace `$function` with `$action`  as it is deprecated, and latest SWIG has removed  support for `$function`