### PR TITLE
Updated Create Generated Clock Syntax

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 
 using namespace sdcparse;
 
+void print_object_id(ObjectId object_id);
 void print_object_id_vec(const std::vector<ObjectId>& group);
 void print_from_to_object_id_vec(const std::vector<ObjectId>& from, const std::vector<ObjectId>& to);
 
@@ -81,8 +82,8 @@ public:
             flushing_printf(" -name %s",
                    cmd.name.c_str());
         }
-        std::string source_name = obj_database.get_object_name(ObjectId(cmd.source));
-        flushing_printf(" -source %s", source_name.c_str());
+        flushing_printf(" -source ");
+        print_object_id_vec(cmd.sources);
         if (cmd.divide_by != sdcparse::UNINITIALIZED_INT)
             flushing_printf(" -divide_by %d", cmd.divide_by);
         if (cmd.multiply_by != sdcparse::UNINITIALIZED_INT)
@@ -297,14 +298,18 @@ int main(int argc, char **argv) {
     return 0;
 }
 
+void print_object_id(ObjectId object_id) {
+    size_t object_id_val = static_cast<size_t>(object_id);
+    flushing_printf("__vtr_obj_%lld", static_cast<long long int>(object_id_val));
+}
+
 void print_object_id_vec(const std::vector<ObjectId>& object_ids) {
     if (object_ids.empty())
         return;
 
     flushing_printf("{");
     for (size_t i = 0; i < object_ids.size(); ++i) {
-        size_t object_id_val = static_cast<size_t>(object_ids[i]);
-        flushing_printf("__vtr_obj_%lld", static_cast<long long int>(object_id_val));
+        print_object_id(object_ids[i]);
 
         if (i != object_ids.size() - 1) {
             flushing_printf(" ");

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -193,7 +193,7 @@ struct CreateClock {
 
 struct CreateGeneratedClock {
     std::string name = "";
-    ObjectId source = ObjectId::INVALID();
+    std::vector<ObjectId> sources;
     int divide_by = UNINITIALIZED_INT;
     int multiply_by = UNINITIALIZED_INT;
     bool add = false;

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -59,14 +59,14 @@ void libsdcparse_create_clock_internal(double period,
 }
 
 void libsdcparse_create_generated_clock_internal(const std::string& name,
-                                                 sdcparse::ObjectId source,
+                                                 const std::vector<sdcparse::ObjectId>& sources,
                                                  int divide_by,
                                                  int multiply_by,
                                                  bool add,
                                                  const std::vector<sdcparse::ObjectId>& targets) {
     sdcparse::CreateGeneratedClock create_gen_clock_cmd;
     create_gen_clock_cmd.name = name;
-    create_gen_clock_cmd.source = source;
+    create_gen_clock_cmd.sources = sources;
     create_gen_clock_cmd.divide_by = divide_by;
     create_gen_clock_cmd.multiply_by = multiply_by;
     create_gen_clock_cmd.add = add;

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -35,11 +35,11 @@ void libsdcparse_create_clock_internal(double period,
                                         const std::vector<sdcparse::ObjectId>& targets);
 
 void libsdcparse_create_generated_clock_internal(const std::string& name,
-                                                  sdcparse::ObjectId source,
-                                                  int divide_by,
-                                                  int multiply_by,
-                                                  bool add,
-                                                  const std::vector<sdcparse::ObjectId>& targets);
+                                                 const std::vector<sdcparse::ObjectId>& sources,
+                                                 int divide_by,
+                                                 int multiply_by,
+                                                 bool add,
+                                                 const std::vector<sdcparse::ObjectId>& targets);
 
 void libsdcparse_set_clock_groups_internal(const std::vector<sdcparse::ObjectId>& clock_list,
                                             const std::vector<int>& clock_group_start_pos,

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -271,7 +271,7 @@ proc create_generated_clock {args} {
         flags   {-name -source -divide_by -multiply_by}
         bools   {-add}
         pos     {targets}
-        require {-source targets}
+        require {-source}
         types   {-divide_by integer -multiply_by integer}
     }
 
@@ -279,10 +279,7 @@ proc create_generated_clock {args} {
 
     set name [dict get $params -name]
 
-    set src [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params -source] {port pin net}]
-    if {[llength $src] != 1} {
-        error "create_generated_clock: Only one source can be defined, found: '$src'"
-    }
+    set id_sources [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params -source] {port pin net}]
 
     set divide_by [dict get $params -divide_by]
     if {$divide_by == ""} {
@@ -303,9 +300,9 @@ proc create_generated_clock {args} {
 
     set add [dict get $params -add]
 
-    set id_targets [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params targets] {port}]
+    set id_targets [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params targets] {port pin net}]
 
-    libsdcparse_create_generated_clock_internal $name $src $divide_by $multiply_by $add $id_targets
+    libsdcparse_create_generated_clock_internal $name $id_sources $divide_by $multiply_by $add $id_targets
 }
 
 proc set_clock_groups {args} {

--- a/test/basic/create_generated_clock.sdc
+++ b/test/basic/create_generated_clock.sdc
@@ -8,20 +8,30 @@ puts [libsdcparse_create_port "gen_clk1" -direction INPUT]
 puts [libsdcparse_create_port "gen_clk2" -direction INPUT]
 # CHECK: [[gen_clk3_port_ptr:__vtr_obj_[0-9]+]]
 puts [libsdcparse_create_port "gen_clk3" -direction INPUT]
+# CHECK: [[clk4_port_ptr:__vtr_obj_[0-9]+]]
+puts [libsdcparse_create_port "clk4" -direction INPUT]
+# CHECK: [[clk4_net_ptr:__vtr_obj_[0-9]+]]
+puts [libsdcparse_create_net "clk4"]
 
 create_clock -period 1.0 clk1
 
-# CHECK: create_generated_clock -source clk1 -divide_by 4 {[[gen_clk1_port_ptr]]}
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -divide_by 4 {[[gen_clk1_port_ptr]]}
 create_generated_clock -source clk1 -divide_by 4 gen_clk1
 
 # CHECK: gen_clk1: {{__vtr_obj_[0-9]+}}
 puts "gen_clk1: [get_clocks gen_clk1]"
 
-# CHECK: create_generated_clock -source clk1 -multiply_by 5 {[[gen_clk2_port_ptr]]}
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -multiply_by 5 {[[gen_clk2_port_ptr]]}
 create_generated_clock -source clk1 -multiply_by 5 gen_clk2
 
-# CHECK: create_generated_clock -name gen_clk_custom_name -source clk1 -multiply_by 6 {[[gen_clk3_port_ptr]]}
+# CHECK: create_generated_clock -name gen_clk_custom_name -source {[[clk1_port_ptr]]} -multiply_by 6 {[[gen_clk3_port_ptr]]}
 create_generated_clock -name gen_clk_custom_name -source clk1 -multiply_by 6 gen_clk3
 
-# CHECK: create_generated_clock -name gen_clk4 -source clk1 -multiply_by 8 -add {[[gen_clk2_port_ptr]]}
+# CHECK: create_generated_clock -name gen_clk4 -source {[[clk1_port_ptr]]} -multiply_by 8 -add {[[gen_clk2_port_ptr]]}
 create_generated_clock -name gen_clk4 -source clk1 -multiply_by 8 gen_clk2 -add
+
+# CHECK: create_generated_clock -name gen_clk5 -source {[[clk1_port_ptr]]}
+create_generated_clock -name gen_clk5 -source clk1 -divide_by 2
+
+# CHECK: create_generated_clock -source {[[clk4_port_ptr]] [[clk4_net_ptr]]} -divide_by 2 {[[gen_clk1_port_ptr]]}
+create_generated_clock -source clk4 -divide_by 2 gen_clk1

--- a/test/basic/create_generated_clock.sdc
+++ b/test/basic/create_generated_clock.sdc
@@ -30,7 +30,7 @@ create_generated_clock -name gen_clk_custom_name -source clk1 -multiply_by 6 gen
 # CHECK: create_generated_clock -name gen_clk4 -source {[[clk1_port_ptr]]} -multiply_by 8 -add {[[gen_clk2_port_ptr]]}
 create_generated_clock -name gen_clk4 -source clk1 -multiply_by 8 gen_clk2 -add
 
-# CHECK: create_generated_clock -name gen_clk5 -source {[[clk1_port_ptr]]}
+# CHECK: create_generated_clock -name gen_clk5 -source {[[clk1_port_ptr]]} -divide_by 2
 create_generated_clock -name gen_clk5 -source clk1 -divide_by 2
 
 # CHECK: create_generated_clock -source {[[clk4_port_ptr]] [[clk4_net_ptr]]} -divide_by 2 {[[gen_clk1_port_ptr]]}

--- a/test/strong/create_generated_clock/missing_targets.sdc
+++ b/test/strong/create_generated_clock/missing_targets.sdc
@@ -1,9 +1,0 @@
-# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
-
-libsdcparse_create_port "clk" -direction INPUT
-libsdcparse_create_port "gen_clk" -direction INPUT
-
-create_clock -period 1 clk
-
-# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: The argument 'targets' is required.
-create_generated_clock -source clk -divide_by 4


### PR DESCRIPTION
While working on implementing the create_generated_clock command in VPR, I found that the syntax originally outlined was not enough. Updated to make it better.

In the future, we will need to add -edges to the syntax; but what we have should be sufficient for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated clocks now support multiple source objects instead of a single source, enabling more flexible clock derivation configurations.

* **Tests**
  * Updated test cases to validate multiple-source functionality for generated clocks.
  * Removed obsolete test case for single-source error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->