### PR TITLE
[SetIoDelay] Added Clock Object Input Instead of String

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,11 +119,13 @@ public:
             flushing_printf("set_output_delay");
         }
 
-        // The clock name can be empty, meaning the arrival time is
+        // The associated clocks can be empty, meaning the arrival time is
         // with respect to all clocks that arrive at the reference
         // pin.
-        if (!cmd.clock_name.empty())
-            flushing_printf(" -clock %s", cmd.clock_name.c_str());
+        if (!cmd.associated_clocks.empty()) {
+            flushing_printf(" -clock ");
+            print_object_id_vec(cmd.associated_clocks);
+        }
 
         if (cmd.is_max) {
             flushing_printf(" -max");

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -214,7 +214,7 @@ struct SetIoDelay {
                                                     // provided, it is up to the application to handle the case 
                                                     // where both are left unspecified (which SDC treats as 
                                                     // implicitly specifying both)
-    std::string clock_name = "";                    //Name of the clock this constraint is associated with
+    std::vector<ObjectId> associated_clocks;        //The clocks this constraint is associated with
     double delay = UNINITIALIZED_FLOAT;             //The maximum input delay allowed on the target ports
     std::vector<ObjectId> target_ports;             //The target ports
 };

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -158,14 +158,14 @@ void libsdcparse_set_multicycle_path_internal(bool is_setup,
 
 void libsdcparse_set_input_delay_internal(bool max_delay_flag,
                                           bool min_delay_flag,
-                                          const std::string& clock_name,
+                                          const std::vector<sdcparse::ObjectId>& associated_clocks,
                                           double delay,
                                           const std::vector<sdcparse::ObjectId>& targets) {
 
     sdcparse::SetIoDelay set_input_delay_cmd;
     set_input_delay_cmd.is_max = max_delay_flag;
     set_input_delay_cmd.is_min = min_delay_flag;
-    set_input_delay_cmd.clock_name = clock_name;
+    set_input_delay_cmd.associated_clocks = associated_clocks;
     set_input_delay_cmd.delay = delay;
     set_input_delay_cmd.target_ports = targets;
     set_input_delay_cmd.type = sdcparse::IoDelayType::INPUT;
@@ -176,14 +176,14 @@ void libsdcparse_set_input_delay_internal(bool max_delay_flag,
 
 void libsdcparse_set_output_delay_internal(bool max_delay_flag,
                                            bool min_delay_flag,
-                                           const std::string& clock_name,
+                                           const std::vector<sdcparse::ObjectId>& associated_clocks,
                                            double delay,
                                            const std::vector<sdcparse::ObjectId>& targets) {
 
     sdcparse::SetIoDelay set_output_delay_cmd;
     set_output_delay_cmd.is_max = max_delay_flag;
     set_output_delay_cmd.is_min = min_delay_flag;
-    set_output_delay_cmd.clock_name = clock_name;
+    set_output_delay_cmd.associated_clocks = associated_clocks;
     set_output_delay_cmd.delay = delay;
     set_output_delay_cmd.target_ports = targets;
     set_output_delay_cmd.type = sdcparse::IoDelayType::OUTPUT;

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -65,16 +65,16 @@ void libsdcparse_set_multicycle_path_internal(bool is_setup,
                                                int path_multiplier);
 
 void libsdcparse_set_input_delay_internal(bool max_delay_flag,
-                                           bool min_delay_flag,
-                                           const std::string& clock_name,
-                                           double delay,
-                                           const std::vector<sdcparse::ObjectId>& targets);
+                                          bool min_delay_flag,
+                                          const std::vector<sdcparse::ObjectId>& associated_clocks,
+                                          double delay,
+                                          const std::vector<sdcparse::ObjectId>& targets);
 
 void libsdcparse_set_output_delay_internal(bool max_delay_flag,
-                                            bool min_delay_flag,
-                                            const std::string& clock_name,
-                                            double delay,
-                                            const std::vector<sdcparse::ObjectId>& targets);
+                                           bool min_delay_flag,
+                                           const std::vector<sdcparse::ObjectId>& associated_clocks,
+                                           double delay,
+                                           const std::vector<sdcparse::ObjectId>& targets);
 
 void libsdcparse_set_clock_uncertainty_internal(bool is_setup,
                                                  bool is_hold,

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -198,7 +198,7 @@ proc libsdcparse_convert_to_objects {cmd_name targets object_type_list} {
     }
 
     if {[llength $targets] != 0 && [llength $id_targets] == 0} {
-        error "$cmd_name: Unknown target(s): $targets. Expected target(s) of type $object_type_list."
+        error "$cmd_name: Unknown target(s): $targets. Expected target(s) of type $object_type_list, found none."
     }
 
     return $id_targets
@@ -443,7 +443,9 @@ proc set_input_delay {args} {
 
     set id_targets [libsdcparse_convert_to_objects "set_input_delay" [dict get $params targets] {port pin}]
 
-    libsdcparse_set_input_delay_internal [dict get $params -max] [dict get $params -min] [dict get $params -clock] [dict get $params delay] $id_targets
+    set associated_clocks [libsdcparse_convert_to_objects "set_input_delay" [dict get $params -clock] {clock}]
+
+    libsdcparse_set_input_delay_internal [dict get $params -max] [dict get $params -min] $associated_clocks [dict get $params delay] $id_targets
 }
 
 proc set_output_delay {args} {
@@ -461,7 +463,9 @@ proc set_output_delay {args} {
 
     set id_targets [libsdcparse_convert_to_objects "set_output_delay" [dict get $params targets] {port pin}]
 
-    libsdcparse_set_output_delay_internal [dict get $params -max] [dict get $params -min] [dict get $params -clock] [dict get $params delay] $id_targets
+    set associated_clocks [libsdcparse_convert_to_objects "set_output_delay" [dict get $params -clock] {clock}]
+
+    libsdcparse_set_output_delay_internal [dict get $params -max] [dict get $params -min] $associated_clocks [dict get $params delay] $id_targets
 }
 
 proc set_clock_uncertainty {args} {

--- a/test/basic/set_input_delay.sdc
+++ b/test/basic/set_input_delay.sdc
@@ -22,24 +22,29 @@ puts [libsdcparse_create_port "A4" -direction INPUT]
 # CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[clk1_port_ptr]]}
 create_clock -period 1.0 clk1
 
-# TODO: We should really be passing the pointer to the clock to the tool.
-# CHECK: set_input_delay -clock clk1 {{0.0*}} {[[in1_port_ptr]]}
+# CHECK: clk1: [[clk1_clock_ptr:__vtr_obj_[0-9]+]]
+puts "clk1: [get_clocks clk1]"
+
+# CHECK: set_input_delay -clock {[[clk1_clock_ptr]]} {{0.0*}} {[[in1_port_ptr]]}
 set_input_delay -clock clk1 0 in1
 
 # CHECK: create_clock -period {{2.0*}} -waveform {{{0.0*}} {{1.0*}}} -name virtual_clock
 create_clock -name virtual_clock -period 2.0
 
-# CHECK: set_input_delay -clock virtual_clock {{1.0*}} {[[in2_port_ptr]]}
+# CHECK: virtual_clock: [[virtual_clock_clock_ptr:__vtr_obj_[0-9]+]]
+puts "virtual_clock: [get_clocks virtual_clock]"
+
+# CHECK: set_input_delay -clock {[[virtual_clock_clock_ptr]]} {{1.0*}} {[[in2_port_ptr]]}
 set_input_delay -clock virtual_clock 1.0 in2
 
-# CHECK: set_input_delay -clock clk1 -max {{0.50*}} {[[in3_port_ptr]]}
+# CHECK: set_input_delay -clock {[[clk1_clock_ptr]]} -max {{0.50*}} {[[in3_port_ptr]]}
 set_input_delay -clock clk1 -max 0.5 in3
 
-# CHECK: set_input_delay -clock clk1 -min {{1.0*}} {[[in4_port_ptr]]}
+# CHECK: set_input_delay -clock {[[clk1_clock_ptr]]} -min {{1.0*}} {[[in4_port_ptr]]}
 set_input_delay -clock clk1 -min 1 in4
 
 # TODO: The order may not be guaranteed. Need to make this more stable.
-# CHECK: set_input_delay -clock virtual_clock {{0.0*}} {[[A1_port_ptr]] [[A2_port_ptr]] [[A3_port_ptr]] [[A4_port_ptr]]}
+# CHECK: set_input_delay -clock {[[virtual_clock_clock_ptr]]} {{0.0*}} {[[A1_port_ptr]] [[A2_port_ptr]] [[A3_port_ptr]] [[A4_port_ptr]]}
 set_input_delay -clock virtual_clock 0.0 [get_ports A*]
 
 # CHECK: set_input_delay {{0.0*}} {[[in1_port_ptr]]}

--- a/test/basic/set_output_delay.sdc
+++ b/test/basic/set_output_delay.sdc
@@ -22,24 +22,29 @@ puts [libsdcparse_create_port "A4" -direction INPUT]
 # CHECK: create_clock -period {{1.0*}} -waveform {{{0.0*}} {{0.50*}}} {[[clk1_port_ptr]]}
 create_clock -period 1.0 clk1
 
-# TODO: We should really be passing the pointer to the clock to the tool.
-# CHECK: set_output_delay -clock clk1 {{0.0*}} {[[in1_port_ptr]]}
+# CHECK: clk1: [[clk1_clock_ptr:__vtr_obj_[0-9]+]]
+puts "clk1: [get_clocks clk1]"
+
+# CHECK: set_output_delay -clock {[[clk1_clock_ptr]]} {{0.0*}} {[[in1_port_ptr]]}
 set_output_delay -clock clk1 0 in1
 
 # CHECK: create_clock -period {{2.0*}} -waveform {{{0.0*}} {{1.0*}}} -name virtual_clock
 create_clock -name virtual_clock -period 2.0
 
-# CHECK: set_output_delay -clock virtual_clock {{1.0*}} {[[in2_port_ptr]]}
+# CHECK: virtual_clock: [[virtual_clock_clock_ptr:__vtr_obj_[0-9]+]]
+puts "virtual_clock: [get_clocks virtual_clock]"
+
+# CHECK: set_output_delay -clock {[[virtual_clock_clock_ptr]]} {{1.0*}} {[[in2_port_ptr]]}
 set_output_delay -clock virtual_clock 1.0 in2
 
-# CHECK: set_output_delay -clock clk1 -max {{0.50*}} {[[in3_port_ptr]]}
+# CHECK: set_output_delay -clock {[[clk1_clock_ptr]]} -max {{0.50*}} {[[in3_port_ptr]]}
 set_output_delay -clock clk1 -max 0.5 in3
 
-# CHECK: set_output_delay -clock clk1 -min {{1.0*}} {[[in4_port_ptr]]}
+# CHECK: set_output_delay -clock {[[clk1_clock_ptr]]} -min {{1.0*}} {[[in4_port_ptr]]}
 set_output_delay -clock clk1 -min 1 in4
 
 # TODO: The order may not be guaranteed. Need to make this more stable.
-# CHECK: set_output_delay -clock virtual_clock {{0.0*}} {[[A1_port_ptr]] [[A2_port_ptr]] [[A3_port_ptr]] [[A4_port_ptr]]}
+# CHECK: set_output_delay -clock {[[virtual_clock_clock_ptr]]} {{0.0*}} {[[A1_port_ptr]] [[A2_port_ptr]] [[A3_port_ptr]] [[A4_port_ptr]]}
 set_output_delay -clock virtual_clock 0.0 [get_ports A*]
 
 # CHECK: set_output_delay {{0.0*}} {[[in1_port_ptr]]}

--- a/test/doc_examples/C.sdc
+++ b/test/doc_examples/C.sdc
@@ -27,8 +27,8 @@ set_clock_groups -asynchronous -group {clk} -group {clk2}
 
 # TODO: This is not technically correct. We need to produce warnings and only
 #       set the input delays on the input ports.
-# CHECK: set_input_delay -clock virtual_io_clock -max {{0.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
+# CHECK: set_input_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{0.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
 set_input_delay -clock virtual_io_clock -max 0 [get_ports {*}]
 
-# CHECK: set_output_delay -clock virtual_io_clock -max {{0.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
+# CHECK: set_output_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{0.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
 set_output_delay -clock virtual_io_clock -max 0 [get_ports {*}]

--- a/test/doc_examples/D.sdc
+++ b/test/doc_examples/D.sdc
@@ -24,8 +24,8 @@ create_clock -period 2.5 -name virtual_io_clock
 
 # TODO: This is not technically correct. We need to produce warnings and only
 #       set the input delays on the input ports.
-# CHECK: set_input_delay -clock virtual_io_clock -max {{1.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
+# CHECK: set_input_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{1.0*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
 set_input_delay -clock virtual_io_clock -max 1 [get_ports {*}]
 
-# CHECK: set_output_delay -clock virtual_io_clock -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
+# CHECK: set_output_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[out1_port_ptr]] [[out2_port_ptr]] [[clk_port_ptr]] [[clk2_port_ptr]]}
 set_output_delay -clock virtual_io_clock -max 0.5 [get_ports {*}]

--- a/test/doc_examples/E.sdc
+++ b/test/doc_examples/E.sdc
@@ -40,9 +40,9 @@ set_max_delay 17 -from [get_clocks {input_clk}] -to [get_clocks {output_clk}]
 set_multicycle_path -setup -from [get_clocks {clk}] -to [get_clocks {clk2}] 3
 
 # TODO: The order here is not guaranteed.
-# CHECK: set_input_delay -clock input_clk -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[in3_port_ptr]]}
+# CHECK: set_input_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[in3_port_ptr]]}
 set_input_delay -clock input_clk -max 0.5 [get_ports {in1 in2 in3}]
 
 # TODO: The order here is not guaranteed.
-# CHECK: set_output_delay -clock output_clk -max {{1.0*}} {[[out1_port_ptr]] [[out2_port_ptr]]}
+# CHECK: set_output_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{1.0*}} {[[out1_port_ptr]] [[out2_port_ptr]]}
 set_output_delay -clock output_clk -max 1 [get_ports {out*}]

--- a/test/doc_examples/F.sdc
+++ b/test/doc_examples/F.sdc
@@ -44,11 +44,11 @@ set_clock_groups -asynchronous -group input_clk -group clk2
 set_false_path -from [get_clocks {clk}] -to [get_clocks {output_clk}]
 
 # TODO: The order here is not guaranteed.
-# CHECK: set_input_delay -clock input_clk -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[in3_port_ptr]]}
+# CHECK: set_input_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{0.50*}} {[[in1_port_ptr]] [[in2_port_ptr]] [[in3_port_ptr]]}
 set_input_delay -clock input_clk -max 0.5 [get_ports {in1 in2 in3}]
 
 # TODO: The order here is not guaranteed.
-# CHECK: set_output_delay -clock output_clk -max {{1.0*}} {[[out1_port_ptr]] [[out2_port_ptr]]}
+# CHECK: set_output_delay -clock {{{__vtr_obj_[0-9]+}}} -max {{1.0*}} {[[out1_port_ptr]] [[out2_port_ptr]]}
 set_output_delay -clock output_clk -max 1 [get_ports {out*}]
 
 # CHECK: set_max_delay {{17.0*}} -from {__vtr_obj_11} -to {__vtr_obj_12}

--- a/test/old_tests/test.sdc
+++ b/test/old_tests/test.sdc
@@ -142,4 +142,4 @@ clk4} \
 #Spaced Comments
 
 #Non-empty line at end of file
-set_output_delay -clock eof_test -max 1.7293 [ get_ports {eof_test_port*} ]
+set_output_delay -clock input_clk -max 1.7293 [ get_ports {eof_test_port*} ]

--- a/test/old_tests/test_io_min_max.sdc
+++ b/test/old_tests/test_io_min_max.sdc
@@ -8,6 +8,9 @@ puts [libsdcparse_create_port "in3" -direction INPUT]
 puts [libsdcparse_create_port "out1" -direction OUTPUT]
 puts [libsdcparse_create_port "out2" -direction OUTPUT]
 
+create_clock -period 10.0 -name input_clk
+create_clock -period 20.0 -name output_clk
+
 #I/O Delay
 set_input_delay -clock input_clk -max -min 0.5 [get_ports {in1 in2 in3}]
 set_output_delay -clock output_clk -max -min 1 [get_ports {out*}]

--- a/test/strong/set_io_delay/set_io_delay_wildcard.sdc
+++ b/test/strong/set_io_delay/set_io_delay_wildcard.sdc
@@ -1,0 +1,16 @@
+# RUN: %sdcparse-test %s 2>&1 | filecheck %s
+
+# CHECK-NEXT: [[in1_port_ptr:__vtr_obj_[0-9]+]]
+puts [libsdcparse_create_port "in1" -direction INPUT]
+
+# CHECK: create_clock -period {{10.0*}} -waveform {{{0.0*}} {{5.0*}}} -name clk
+create_clock -period 10.0 -name clk
+
+# CHECK: clk: [[clk_clock_ptr:__vtr_obj_[0-9]+]]
+puts "clk: [get_clocks clk]"
+
+# CHECK: set_input_delay -clock {[[clk_clock_ptr]]} -max {{0.50*}} {[[in1_port_ptr]]}
+set_input_delay -clock * -max 0.5 [get_ports in1]
+
+# CHECK: set_output_delay -clock {[[clk_clock_ptr]]} -max {{0.50*}} {[[in1_port_ptr]]}
+set_output_delay -clock * -max 0.5 [get_ports in1]

--- a/test/strong/set_io_delay/set_io_delay_wildcard.sdc
+++ b/test/strong/set_io_delay/set_io_delay_wildcard.sdc
@@ -1,6 +1,6 @@
 # RUN: %sdcparse-test %s 2>&1 | filecheck %s
 
-# CHECK-NEXT: [[in1_port_ptr:__vtr_obj_[0-9]+]]
+# CHECK: [[in1_port_ptr:__vtr_obj_[0-9]+]]
 puts [libsdcparse_create_port "in1" -direction INPUT]
 
 # CHECK: create_clock -period {{10.0*}} -waveform {{{0.0*}} {{5.0*}}} -name clk

--- a/test/strong/set_io_delay/set_io_delay_wildcard_none.sdc
+++ b/test/strong/set_io_delay/set_io_delay_wildcard_none.sdc
@@ -1,0 +1,7 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+# CHECK-NEXT: [[in1_port_ptr:__vtr_obj_[0-9]+]]
+puts [libsdcparse_create_port "in1" -direction INPUT]
+
+# CHECK: set_input_delay: Unknown target(s): *
+set_input_delay -clock * -max 0.5 [get_ports in1]

--- a/test/strong/set_io_delay/set_io_delay_wildcard_none.sdc
+++ b/test/strong/set_io_delay/set_io_delay_wildcard_none.sdc
@@ -1,6 +1,6 @@
 # RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
 
-# CHECK-NEXT: [[in1_port_ptr:__vtr_obj_[0-9]+]]
+# CHECK: [[in1_port_ptr:__vtr_obj_[0-9]+]]
 puts [libsdcparse_create_port "in1" -direction INPUT]
 
 # CHECK: set_input_delay: Unknown target(s): *


### PR DESCRIPTION
The set input/output delay constraints took the clock object names as
raw strings. This limited the usability of these constraints and caused
funny issues with the get_clocks command.

Fixed these issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting for unresolved clock and port targets in timing constraints.

* **Tests**
  * Extended test coverage for wildcard clock target handling in timing constraint commands.
  * Added validation tests for edge cases in clock resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->