### PR TITLE
[SDC] Updated Generated Clock Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/stack.hh
 __pycache__/
 
 *.swp
+
+.vscode/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <cmath>
 #include "sdcparse.hpp"
 
 // The TCL parser uses its own buffers when printing to stdout. This means that
@@ -90,6 +91,32 @@ public:
             flushing_printf(" -multiply_by %d", cmd.multiply_by);
         if (cmd.add) {
             flushing_printf(" -add");
+        }
+        if (!cmd.edges.empty()) {
+            flushing_printf(" -edges {");
+            for (size_t i = 0; i < cmd.edges.size(); i++) {
+                if (i != 0) {
+                    flushing_printf(" ");
+                }
+                flushing_printf("%f", cmd.edges[i]);
+            }
+            flushing_printf("}");
+        }
+        if (!cmd.edge_shift.empty()) {
+            flushing_printf(" -edge_shift {");
+            for (size_t i = 0; i < cmd.edge_shift.size(); i++) {
+                if (i != 0) {
+                    flushing_printf(" ");
+                }
+                flushing_printf("%f", cmd.edge_shift[i]);
+            }
+            flushing_printf("}");
+        }
+        if (cmd.invert) {
+            flushing_printf(" -invert");
+        }
+        if (!std::isnan(cmd.duty_cycle)) {
+            flushing_printf(" -duty_cycle %f", cmd.duty_cycle);
         }
         if (!cmd.targets.empty()) {
             flushing_printf(" ");

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -194,9 +194,9 @@ struct CreateClock {
 struct CreateGeneratedClock {
     std::string name = "";                      //Name of the generated clock
     std::vector<ObjectId> sources;              //The master clock pin(s)/port(s) this clock is derived from
-    int divide_by = UNINITIALIZED_INT;          //Divide the master clock period by this integer (UNINITIALIZED_INT if unset)
-    int multiply_by = UNINITIALIZED_INT;        //Multiply the master clock period by this integer (UNINITIALIZED_INT if unset)
-                                                // Note: divide_by and multiply_by are mutually exclusive; exactly one of
+    int divide_by = UNINITIALIZED_INT;          //Divide the master clock frequency by this integer (UNINITIALIZED_INT if unset)
+    int multiply_by = UNINITIALIZED_INT;        //Multiply the master clock frequency by this integer (UNINITIALIZED_INT if unset)
+                                                // Note: divide_by, multiply_by, and edges are mutually exclusive; exactly one of
                                                 // divide_by, multiply_by, or edges must be provided
     bool add = false;                           //If true, add this clock to any existing clocks on the target rather
                                                 // than replacing them

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -197,6 +197,10 @@ struct CreateGeneratedClock {
     int divide_by = UNINITIALIZED_INT;
     int multiply_by = UNINITIALIZED_INT;
     bool add = false;
+    std::vector<double> edges;
+    std::vector<double> edge_shift;
+    bool invert = false;
+    double duty_cycle = UNINITIALIZED_FLOAT;
     std::vector<ObjectId> targets;
 };
 

--- a/src/sdcparse.hpp
+++ b/src/sdcparse.hpp
@@ -192,16 +192,23 @@ struct CreateClock {
 };
 
 struct CreateGeneratedClock {
-    std::string name = "";
-    std::vector<ObjectId> sources;
-    int divide_by = UNINITIALIZED_INT;
-    int multiply_by = UNINITIALIZED_INT;
-    bool add = false;
-    std::vector<double> edges;
-    std::vector<double> edge_shift;
-    bool invert = false;
-    double duty_cycle = UNINITIALIZED_FLOAT;
-    std::vector<ObjectId> targets;
+    std::string name = "";                      //Name of the generated clock
+    std::vector<ObjectId> sources;              //The master clock pin(s)/port(s) this clock is derived from
+    int divide_by = UNINITIALIZED_INT;          //Divide the master clock period by this integer (UNINITIALIZED_INT if unset)
+    int multiply_by = UNINITIALIZED_INT;        //Multiply the master clock period by this integer (UNINITIALIZED_INT if unset)
+                                                // Note: divide_by and multiply_by are mutually exclusive; exactly one of
+                                                // divide_by, multiply_by, or edges must be provided
+    bool add = false;                           //If true, add this clock to any existing clocks on the target rather
+                                                // than replacing them
+    std::vector<double> edges;                  //List of 3 master-clock edge indices that define the rising edge,
+                                                // falling edge, and next rising edge of the generated clock waveform
+    std::vector<double> edge_shift;             //Per-edge time offset (in the master clock period) applied to each
+                                                // edge in the edges list; must be the same length as edges
+    bool invert = false;                        //If true, invert the generated clock signal relative to the master clock;
+                                                // only valid with divide_by or multiply_by
+    double duty_cycle = UNINITIALIZED_FLOAT;    //Duty cycle as a percentage (0.0–100.0) for the generated clock when
+                                                // using multiply_by (UNINITIALIZED_FLOAT if unset)
+    std::vector<ObjectId> targets;              //The netlist objects (ports/pins/nets) on which the generated clock is created
 };
 
 struct SetIoDelay {

--- a/src/tcl/sdc_commands.cpp
+++ b/src/tcl/sdc_commands.cpp
@@ -63,6 +63,10 @@ void libsdcparse_create_generated_clock_internal(const std::string& name,
                                                  int divide_by,
                                                  int multiply_by,
                                                  bool add,
+                                                 const std::vector<double>& edges,
+                                                 const std::vector<double>& edge_shift,
+                                                 bool invert,
+                                                 double duty_cycle,
                                                  const std::vector<sdcparse::ObjectId>& targets) {
     sdcparse::CreateGeneratedClock create_gen_clock_cmd;
     create_gen_clock_cmd.name = name;
@@ -70,6 +74,14 @@ void libsdcparse_create_generated_clock_internal(const std::string& name,
     create_gen_clock_cmd.divide_by = divide_by;
     create_gen_clock_cmd.multiply_by = multiply_by;
     create_gen_clock_cmd.add = add;
+    create_gen_clock_cmd.edges = edges;
+    create_gen_clock_cmd.edge_shift = edge_shift;
+    create_gen_clock_cmd.invert = invert;
+    if (duty_cycle == -1) {
+        create_gen_clock_cmd.duty_cycle = sdcparse::UNINITIALIZED_FLOAT;
+    } else {
+        create_gen_clock_cmd.duty_cycle = duty_cycle;
+    }
     create_gen_clock_cmd.targets = targets;
 
     check_g_callback_defined();

--- a/src/tcl/sdc_commands.h
+++ b/src/tcl/sdc_commands.h
@@ -39,6 +39,10 @@ void libsdcparse_create_generated_clock_internal(const std::string& name,
                                                  int divide_by,
                                                  int multiply_by,
                                                  bool add,
+                                                 const std::vector<double>& edges,
+                                                 const std::vector<double>& edge_shift,
+                                                 bool invert,
+                                                 double duty_cycle,
                                                  const std::vector<sdcparse::ObjectId>& targets);
 
 void libsdcparse_set_clock_groups_internal(const std::vector<sdcparse::ObjectId>& clock_list,

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -352,6 +352,10 @@ proc create_generated_clock {args} {
 
     set id_targets [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params targets] {port pin net}]
 
+    if {$name == "" && [llength $id_targets] == 0} {
+        error "create_generated_clock: Either name or target must be provided"
+    }
+
     libsdcparse_create_generated_clock_internal $name $id_sources $divide_by $multiply_by $add $edges $edge_shift $invert $duty_cycle $id_targets
 }
 

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -268,11 +268,11 @@ proc create_generated_clock {args} {
     libsdcparse_set_lineno
 
     set spec {
-        flags   {-name -source -divide_by -multiply_by}
-        bools   {-add}
+        flags   {-name -source -divide_by -multiply_by -edges -edge_shift -duty_cycle}
+        bools   {-add -invert}
         pos     {targets}
         require {-source}
-        types   {-divide_by integer -multiply_by integer}
+        types   {-divide_by integer -multiply_by integer -duty_cycle double}
     }
 
     set params [libsdcparse_generic_sdc_parser "create_generated_clock" $spec $args]
@@ -286,23 +286,73 @@ proc create_generated_clock {args} {
         # TODO: This should be made non-magic.
         #       This is UNINITIALIZED_INT
         set divide_by -1
+    } else {
+        if {$divide_by < 1} {
+            error "create_generated_clock: -divide_by must not be less than 1"
+        }
     }
 
     set multiply_by [dict get $params -multiply_by]
     if {$multiply_by == ""} {
         # TODO: This should be made non-magic.
         set multiply_by -1
+    } else {
+        if {$multiply_by < 1} {
+            error "create_generated_clock: -multiply_by must not be less than 1"
+        }
     }
 
-    if {$divide_by == -1 && $multiply_by == -1} {
-        error "create_generated_clock: Either -multiply_by or -divide_by is required."
+    if {$divide_by != -1 && $multiply_by != -1} {
+        error "create_generated_clock: cannot specify both -divide_by and -multiply_by"
+    }
+
+    set duty_cycle [dict get $params -duty_cycle]
+    if {$duty_cycle == ""} {
+        # TODO: This should be made non-magic.
+        set duty_cycle -1.0
+    } else {
+        if {$duty_cycle < 0.0 || $duty_cycle > 100.0} {
+            error "create_generated_clock: -duty_cycle expected to be a percentage from 0.0 to 100.0, given $duty_cycle"
+        }
+        if {$multiply_by == -1} {
+            error "create_generated_clock: -duty_cycle can only be used for clock multiplication"
+        }
+    }
+
+    set edges [dict get $params -edges]
+    if {$edges != "" && [llength $edges] != 3} {
+        error "create_generated_clock: -edges expected to be a list of 3 elements, given $edges"
+    }
+    foreach edge $edges {
+        if {![string is double -strict $edge]} {
+            error "create_generated_clock: -edges expected to be a list of doubles, given a non-double edge: $edge"
+        }
+    }
+
+    set edge_shift [dict get $params -edge_shift]
+    if {$edge_shift != "" && [llength $edge_shift] != [llength $edges]} {
+        error "create_generated_clock: -edge_shift list expected to be the same length as -edges, given $edge_shift"
+    }
+    foreach shift $edge_shift {
+        if {![string is double -strict $shift]} {
+            error "create_generated_clock: -edge_shift expected to be a list of doubles, given a non-double shift: $shift"
+        }
+    }
+
+    if {$divide_by == -1 && $multiply_by == -1 && $edges == ""} {
+        error "create_generated_clock: One of -divide_by, -multiply_by, or -edges must be provided"
     }
 
     set add [dict get $params -add]
 
+    set invert [dict get $params -invert]
+    if {$invert && $multiply_by == -1 && $divide_by == -1} {
+        error "create_generated_clock: -invert can only be used for clock division and multiplication"
+    }
+
     set id_targets [libsdcparse_convert_to_objects "create_generated_clock" [dict get $params targets] {port pin net}]
 
-    libsdcparse_create_generated_clock_internal $name $id_sources $divide_by $multiply_by $add $id_targets
+    libsdcparse_create_generated_clock_internal $name $id_sources $divide_by $multiply_by $add $edges $edge_shift $invert $duty_cycle $id_targets
 }
 
 proc set_clock_groups {args} {

--- a/src/tcl/sdc_wrapper.tcl
+++ b/src/tcl/sdc_wrapper.tcl
@@ -329,6 +329,10 @@ proc create_generated_clock {args} {
         }
     }
 
+    if {$edges != "" && ($divide_by != -1 || $multiply_by != -1)} {
+        error "create_generated_clock: -edges cannot be used with -divide_by or -multiply_by"
+    }
+
     set edge_shift [dict get $params -edge_shift]
     if {$edge_shift != "" && [llength $edge_shift] != [llength $edges]} {
         error "create_generated_clock: -edge_shift list expected to be the same length as -edges, given $edge_shift"

--- a/test/basic/create_generated_clock.sdc
+++ b/test/basic/create_generated_clock.sdc
@@ -35,3 +35,15 @@ create_generated_clock -name gen_clk5 -source clk1 -divide_by 2
 
 # CHECK: create_generated_clock -source {[[clk4_port_ptr]] [[clk4_net_ptr]]} -divide_by 2 {[[gen_clk1_port_ptr]]}
 create_generated_clock -source clk4 -divide_by 2 gen_clk1
+
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -edges {{{1.0*}} {{3.0*}} {{5.0*}}} {[[gen_clk1_port_ptr]]}
+create_generated_clock -source clk1 -edges {1 3 5} gen_clk1
+
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -edges {{{1.0*}} {{3.0*}} {{5.0*}}} -edge_shift {{{1.0*}} {{0.0*}} {{-0.50*}}} {[[gen_clk1_port_ptr]]}
+create_generated_clock -source clk1 -edges {1 3 5} -edge_shift {1.0 0.0 -0.5} gen_clk1
+
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -divide_by 2 -invert {[[gen_clk1_port_ptr]]}
+create_generated_clock -source clk1 -divide_by 2 -invert gen_clk1
+
+# CHECK: create_generated_clock -source {[[clk1_port_ptr]]} -multiply_by 2 -duty_cycle {{25.0*}} {[[gen_clk1_port_ptr]]}
+create_generated_clock -source clk1 -multiply_by 2 -duty_cycle 25.0 gen_clk1

--- a/test/strong/create_generated_clock/both_divide_and_multiply.sdc
+++ b/test/strong/create_generated_clock/both_divide_and_multiply.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: cannot specify both -divide_by and -multiply_by
+create_generated_clock -source clk -divide_by 2 -multiply_by 3 gen_clk

--- a/test/strong/create_generated_clock/divide_by_less_than_1.sdc
+++ b/test/strong/create_generated_clock/divide_by_less_than_1.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -divide_by must not be less than 1
+create_generated_clock -source clk -divide_by 0 gen_clk

--- a/test/strong/create_generated_clock/duty_cycle_out_of_range.sdc
+++ b/test/strong/create_generated_clock/duty_cycle_out_of_range.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -duty_cycle expected to be a percentage from 0.0 to 100.0
+create_generated_clock -source clk -multiply_by 2 -duty_cycle 150.0 gen_clk

--- a/test/strong/create_generated_clock/duty_cycle_without_multiply.sdc
+++ b/test/strong/create_generated_clock/duty_cycle_without_multiply.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -duty_cycle can only be used for clock multiplication
+create_generated_clock -source clk -divide_by 2 -duty_cycle 25.0 gen_clk

--- a/test/strong/create_generated_clock/edge_shift_non_double.sdc
+++ b/test/strong/create_generated_clock/edge_shift_non_double.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edge_shift expected to be a list of doubles, given a non-double shift: abc
+create_generated_clock -source clk -edges {1 3 5} -edge_shift {1.0 abc -0.5} gen_clk

--- a/test/strong/create_generated_clock/edge_shift_wrong_length.sdc
+++ b/test/strong/create_generated_clock/edge_shift_wrong_length.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edge_shift list expected to be the same length as -edges, given
+create_generated_clock -source clk -edges {1 3 5} -edge_shift {1.0 0.0} gen_clk

--- a/test/strong/create_generated_clock/edges_non_double.sdc
+++ b/test/strong/create_generated_clock/edges_non_double.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edges expected to be a list of doubles, given a non-double edge: abc
+create_generated_clock -source clk -edges {1 abc 5} gen_clk

--- a/test/strong/create_generated_clock/edges_with_divide_by.sdc
+++ b/test/strong/create_generated_clock/edges_with_divide_by.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edges cannot be used with -divide_by or -multiply_by
+create_generated_clock -source clk -edges {1 3 5} -divide_by 2 gen_clk

--- a/test/strong/create_generated_clock/edges_with_multiply_by.sdc
+++ b/test/strong/create_generated_clock/edges_with_multiply_by.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edges cannot be used with -divide_by or -multiply_by
+create_generated_clock -source clk -edges {1 3 5} -multiply_by 2 gen_clk

--- a/test/strong/create_generated_clock/edges_wrong_count.sdc
+++ b/test/strong/create_generated_clock/edges_wrong_count.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -edges expected to be a list of 3 elements, given
+create_generated_clock -source clk -edges {1 2} gen_clk

--- a/test/strong/create_generated_clock/invert_without_div_mult.sdc
+++ b/test/strong/create_generated_clock/invert_without_div_mult.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -invert can only be used for clock division and multiplication
+create_generated_clock -source clk -edges {1 3 5} -invert gen_clk

--- a/test/strong/create_generated_clock/missing_div_and_mult.sdc
+++ b/test/strong/create_generated_clock/missing_div_and_mult.sdc
@@ -1,9 +1,0 @@
-# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
-
-libsdcparse_create_port "clk" -direction INPUT
-libsdcparse_create_port "gen_clk" -direction INPUT
-
-create_clock -period 1 clk
-
-# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: Either -multiply_by or -divide_by is required.
-create_generated_clock -source clk gen_clk

--- a/test/strong/create_generated_clock/missing_div_mult_or_edges.sdc
+++ b/test/strong/create_generated_clock/missing_div_mult_or_edges.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: One of -divide_by, -multiply_by, or -edges must be provided
+create_generated_clock -source clk gen_clk

--- a/test/strong/create_generated_clock/missing_name_and_target.sdc
+++ b/test/strong/create_generated_clock/missing_name_and_target.sdc
@@ -1,0 +1,8 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: Either name or target must be provided
+create_generated_clock -source clk -divide_by 4

--- a/test/strong/create_generated_clock/multiply_by_less_than_1.sdc
+++ b/test/strong/create_generated_clock/multiply_by_less_than_1.sdc
@@ -1,0 +1,9 @@
+# RUN: %not %sdcparse-test %s 2>&1 | filecheck %s
+
+libsdcparse_create_port "clk" -direction INPUT
+libsdcparse_create_port "gen_clk" -direction INPUT
+
+create_clock -period 1 clk
+
+# CHECK: Custom Error at line [[# @LINE + 1]]: create_generated_clock: -multiply_by must not be less than 1
+create_generated_clock -source clk -multiply_by 0 gen_clk


### PR DESCRIPTION
The original create_generated_clock syntax was not expressive enough to express most generated clocks. It specifically was not able to generate any non-50% duty-cycle clock. Added more syntax to enable the expression of these generated clocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `create_generated_clock` command with edge timing (`-edges`, `-edge_shift`), inversion (`-invert`), and duty cycle control for advanced clock waveform configuration

* **Tests**
  * Added comprehensive test coverage for new parameters and validation rules

* **Chores**
  * Updated `.gitignore` to exclude VS Code workspace configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->